### PR TITLE
Vulkan PR Fixes

### DIFF
--- a/code/bmpman/bmpman.cpp
+++ b/code/bmpman/bmpman.cpp
@@ -189,6 +189,7 @@ float bitmap_lookup::map_texture_address(float address)
 float bitmap_lookup::get_channel_alpha(float u, float v)
 {
 	Assert( Bitmap_data != NULL );
+	Assertion(Num_channels > 3, "Checked alpha on a bitmap without an alpha channel");
 
 	int x = fl2i(map_texture_address(u) * (Width-1));
 	int y = fl2i(map_texture_address(v) * (Height-1));

--- a/code/def_files/data/effects/msaa-f.sdr
+++ b/code/def_files/data/effects/msaa-f.sdr
@@ -46,12 +46,14 @@ layout (std140) uniform genericData {
 const float voxelDepth = 2.5f;
 const float voxelDepthFalloff = 2.5f;
 
-#define SORT(a, b) if (a > b) { float t = dists[a]; dists[a] = dists[b]; dists[b] = t; }
+#define SORT(a, b) if (dists[a] > dists[b]) { float t = dists[a]; dists[a] = dists[b]; dists[b] = t; }
 
 //The following sorting networks for median calculation are NOT complete. Calculations that don't affect the
 //median entry are removed, and thus, while the median element is correct, the rest of the array is NOT fully sorted
 
 #ifdef SAMPLES_4
+
+#define SAMPLE_CNT 4
 
 float getMedianDist(ivec2 texel) {
 	float dists[4];
@@ -71,6 +73,8 @@ float getMedianDist(ivec2 texel) {
 
 #else
 #ifdef SAMPLES_8
+
+#define SAMPLE_CNT 8
 
 float getMedianDist(ivec2 texel) {
 	float dists[8];
@@ -102,6 +106,8 @@ float getMedianDist(ivec2 texel) {
 
 #else
 #ifdef SAMPLES_16
+
+#define SAMPLE_CNT 16
 
 float getMedianDist(ivec2 texel) {
 	float dists[16];
@@ -166,6 +172,8 @@ float getMedianDist(ivec2 texel) {
 
 #else
 
+#define SAMPLE_CNT samples
+
 //Fallback, do front first
 float getMedianDist(ivec2 texel) {
 	float minDist = -1000000;
@@ -200,7 +208,7 @@ void main()
 	vec4 emissive = vec4(0);
 	float depth = 0;
 
-	for(int i = 0; i < samples; i++) {
+	for(int i = 0; i < SAMPLE_CNT; i++) {
 		vec4 localPos = texelFetch(texPos, texel, i);
 		localPos.z = uncompress_depth_value(localPos.z);
 		//Calculate local weight from distance Voxel, but if the distance is 0 (i.e. no model at all), set weight to 1 to allow stuff like background emissive

--- a/code/globalincs/toolchain/clang.h
+++ b/code/globalincs/toolchain/clang.h
@@ -30,7 +30,7 @@
 #ifdef NO_RESTRICT_USE
 #	define RESTRICT
 #else
-#	define RESTRICT  restrict
+#	define RESTRICT  __restrict
 #endif
 
 #define ASSUME(x)

--- a/code/globalincs/toolchain/gcc.h
+++ b/code/globalincs/toolchain/gcc.h
@@ -31,7 +31,7 @@
 #ifdef NO_RESTRICT_USE
 #   define RESTRICT
 #else
-#   define RESTRICT  restrict
+#   define RESTRICT  __restrict
 #endif
 
 #define ASSUME(x)

--- a/code/globalincs/toolchain/mingw.h
+++ b/code/globalincs/toolchain/mingw.h
@@ -32,7 +32,7 @@
 #ifdef NO_RESTRICT_USE
 #   define RESTRICT
 #else
-#   define RESTRICT  restrict
+#   define RESTRICT  __restrict__
 #endif
 
 #define ASSUME(x)

--- a/code/graphics/opengl/es_compatibility.h
+++ b/code/graphics/opengl/es_compatibility.h
@@ -4,6 +4,7 @@
 #include <vector>
 #include <glad/glad.h>
 #include <KHR/khrplatform.h>
+#include "graphics/util/pixel_swizzle.h"
 /*
 	OpenGL ES 3.2 compatibility layer
 	---------------------------------
@@ -59,106 +60,6 @@
 #define glDepthRange                    glDepthRangef // ES 3.0
 
 /* 
-	Pixel Conversion for unsupported uncompressed formats 
-*/
-
-// BGRA 1_5_5_5_REV -> RGBA 5_5_5_1
-static inline void convert_BGRA1555_REV_to_RGBA5551(const uint16_t* __restrict src, uint16_t* __restrict dst, size_t npx)
-{
-	for (size_t i = 0; i < npx; i++) {
-		const uint16_t s = src[i];
-		uint16_t a = (s >> 15) & 0x1;
-		uint16_t r = (s >> 10) & 0x1F;
-		uint16_t g = (s >> 5) & 0x1F;
-		uint16_t b = (s >> 0) & 0x1F;
-		dst[i] = static_cast<uint16_t>((r << 11) | (g << 6) | (b << 1) | a);
-	}
-}
-
-// BGRA1555_REV -> RGBA8888
-static inline void convert_BGRA1555_REV_to_RGBA8888(const uint16_t* __restrict src, uint8_t* __restrict dstRGBA8, size_t npx)
-{
-	for (size_t i = 0; i < npx; ++i) {
-		uint16_t s = src[i];
-		uint8_t A = (s >> 15) ? 255 : 0;
-		uint8_t R5 = (s >> 10) & 0x1F;
-		uint8_t G5 = (s >> 5) & 0x1F;
-		uint8_t B5 = s & 0x1F;
-		// expand 5 to 8 bits
-		uint8_t R = (R5 << 3) | (R5 >> 2);
-		uint8_t G = (G5 << 3) | (G5 >> 2);
-		uint8_t B = (B5 << 3) | (B5 >> 2);
-		size_t o = 4 * i;
-		dstRGBA8[o + 0] = R;
-		dstRGBA8[o + 1] = G;
-		dstRGBA8[o + 2] = B;
-		dstRGBA8[o + 3] = A;
-	}
-}
-
-// BGR -> RGB
-static inline void convert_BGR_to_RGB(const uint8_t* __restrict src, uint8_t* __restrict dst, size_t npx)
-{
-	for (size_t i = 0, s = 0, t = 0; i < npx; ++i, s += 3, t += 3) {
-		uint8_t b = src[s + 0];
-		uint8_t g = src[s + 1];
-		uint8_t r = src[s + 2];
-		dst[t + 0] = r;
-		dst[t + 1] = g;
-		dst[t + 2] = b;
-	}
-}
-
-// BGRA 8888 -> RGBA 8888
-static inline void convert_BGRA8888_to_RGBA8888(const uint8_t* __restrict src, uint8_t* __restrict dst, size_t npx)
-{
-	for (size_t i = 0; i < npx; i++) {
-		const uint8_t b = src[4 * i + 0];
-		const uint8_t g = src[4 * i + 1];
-		const uint8_t r = src[4 * i + 2];
-		const uint8_t a = src[4 * i + 3];
-		dst[4 * i + 0] = r;
-		dst[4 * i + 1] = g;
-		dst[4 * i + 2] = b;
-		dst[4 * i + 3] = a;
-	}
-}
-
-// BGR 3B -> RGBA 4B
-static inline void convert_BGR_to_RGBA(const uint8_t* __restrict src, uint8_t* __restrict dst, size_t npx)
-{
-	for (size_t i = 0; i < npx; ++i) {
-		const size_t s = i * 3;
-		const size_t t = i * 4;
-		dst[t + 0] = src[s + 2]; // R <- B
-		dst[t + 1] = src[s + 1]; // G
-		dst[t + 2] = src[s + 0]; // B <- R
-		dst[t + 3] = 255;        // A
-	}
-}
-
-// BGRA1555_REV -> RGB888
-static inline void convert_BGRA1555_REV_to_RGB888(const uint16_t* __restrict src, uint8_t* __restrict dstRGB8, size_t npx)
-{
-	for (size_t i = 0; i < npx; ++i) {
-		uint16_t s = src[i];
-		uint8_t R5 = (s >> 10) & 0x1F;
-		uint8_t G5 = (s >> 5) & 0x1F;
-		uint8_t B5 = s & 0x1F;
-
-		// expand 5 to 8 bits
-		uint8_t R = (R5 << 3) | (R5 >> 2);
-		uint8_t G = (G5 << 3) | (G5 >> 2);
-		uint8_t B = (B5 << 3) | (B5 >> 2);
-
-		size_t o = 3 * i;
-		dstRGB8[o + 0] = R;
-		dstRGB8[o + 1] = G;
-		dstRGB8[o + 2] = B;
-	}
-}
-
-/* 
 	Intercept calls to do pixel conversion and format adjustments to something the driver can work with
 	Note: This is only needed for uncompressed texture formats
 */
@@ -187,7 +88,7 @@ static inline void glTexSubImage3D(GLenum target, GLint level, GLint xoff, GLint
 			if (data != nullptr) 
 			{
 				std::vector<uint8_t> scratch(npx * 4); // RGBA8888 = 4 BPP
-				convert_BGRA1555_REV_to_RGBA8888(reinterpret_cast<const uint16_t*>(data), scratch.data(), npx);
+				graphics::util::convert_BGRA1555_REV_to_RGBA8888(reinterpret_cast<const uint16_t*>(data), scratch.data(), npx);
 				glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
 				glad_glTexSubImage3D(target, level, xoff, yoff, zoff, w, h, d, format, type, scratch.data());
 				return;
@@ -198,7 +99,7 @@ static inline void glTexSubImage3D(GLenum target, GLint level, GLint xoff, GLint
 			if (data != nullptr)
 			{
 				std::vector<uint8_t> scratch(npx * 3); // RGB888 = 3 BPP
-				convert_BGRA1555_REV_to_RGB888(reinterpret_cast<const uint16_t*>(data), scratch.data(), npx);
+				graphics::util::convert_BGRA1555_REV_to_RGB888(reinterpret_cast<const uint16_t*>(data), scratch.data(), npx);
 				glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
 				glad_glTexSubImage3D(target, level, xoff, yoff, zoff, w, h, d, format, type, scratch.data());
 				return;
@@ -208,7 +109,7 @@ static inline void glTexSubImage3D(GLenum target, GLint level, GLint xoff, GLint
 			type = GL_UNSIGNED_SHORT_5_5_5_1;
 			if (data != nullptr) {
 				std::vector<uint8_t> scratch(npx * 2); // RGBA5551 = 2 BPP
-				convert_BGRA1555_REV_to_RGBA5551(reinterpret_cast<const uint16_t*>(data),
+				graphics::util::convert_BGRA1555_REV_to_RGBA5551(reinterpret_cast<const uint16_t*>(data),
 					reinterpret_cast<uint16_t*>(scratch.data()),
 					npx);
 				glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
@@ -226,7 +127,7 @@ static inline void glTexSubImage3D(GLenum target, GLint level, GLint xoff, GLint
 			format = GL_RGBA;
 			if (data != nullptr) {
 				std::vector<uint8_t> scratch(npx * 4); // RGBA8888 = 4 BPP
-				convert_BGR_to_RGBA(static_cast<const uint8_t*>(data), scratch.data(), npx);
+				graphics::util::convert_BGR_to_RGBA(static_cast<const uint8_t*>(data), scratch.data(), npx);
 				glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
 				glad_glTexSubImage3D(target, level, xoff, yoff, zoff, w, h, d, format, type, scratch.data());
 				return;
@@ -237,7 +138,7 @@ static inline void glTexSubImage3D(GLenum target, GLint level, GLint xoff, GLint
 			format = GL_RGB;
 			if (data != nullptr) {
 				std::vector<uint8_t> scratch(npx * 3); // RGB888 = 3 BPP
-				convert_BGR_to_RGB(static_cast<const uint8_t*>(data), scratch.data(), npx);
+				graphics::util::convert_BGR_to_RGB(static_cast<const uint8_t*>(data), scratch.data(), npx);
 				glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
 				glad_glTexSubImage3D(target, level, xoff, yoff, zoff, w, h, d, format, type, scratch.data());
 				return;
@@ -251,7 +152,7 @@ static inline void glTexSubImage3D(GLenum target, GLint level, GLint xoff, GLint
 		if (data != nullptr /* && !GLAD_GL_EXT_texture_format_BGRA8888*/) {
 			// Conversion forced on because the check either does not work or buggy impl on Mali
 			std::vector<uint8_t> scratch(npx * 4);
-			convert_BGRA8888_to_RGBA8888(reinterpret_cast<const uint8_t*>(data), scratch.data(), npx);
+			graphics::util::convert_BGRA8888_to_RGBA8888(reinterpret_cast<const uint8_t*>(data), scratch.data(), npx);
 			glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
 			glad_glTexSubImage3D(target, level, xoff, yoff, zoff, w, h, d, GL_RGBA, type, scratch.data());
 			return;

--- a/code/graphics/util/pixel_swizzle.cpp
+++ b/code/graphics/util/pixel_swizzle.cpp
@@ -1,0 +1,156 @@
+#include "graphics/util/pixel_swizzle.h"
+
+namespace graphics {
+namespace util {
+
+void swizzle_bgra_to_rgba(uint8_t* pixels, size_t count)
+{
+	for (size_t i = 0; i < count; i++) {
+		size_t off = i * 4;
+		uint8_t tmp = pixels[off + 0];
+		pixels[off + 0] = pixels[off + 2];
+		pixels[off + 2] = tmp;
+	}
+}
+
+void convert_BGRA8888_to_RGBA8888(const uint8_t* RESTRICT src, uint8_t* RESTRICT dst, size_t count)
+{
+	for (size_t i = 0; i < count; i++) {
+		const uint8_t b = src[4 * i + 0];
+		const uint8_t g = src[4 * i + 1];
+		const uint8_t r = src[4 * i + 2];
+		const uint8_t a = src[4 * i + 3];
+		dst[4 * i + 0] = r;
+		dst[4 * i + 1] = g;
+		dst[4 * i + 2] = b;
+		dst[4 * i + 3] = a;
+	}
+}
+
+void convert_RGBA8888_to_RGB888(const uint8_t* RESTRICT src, uint8_t* RESTRICT dst, size_t count)
+{
+	for (size_t i = 0; i < count; ++i) {
+		dst[i * 3 + 0] = src[i * 4 + 0];
+		dst[i * 3 + 1] = src[i * 4 + 1];
+		dst[i * 3 + 2] = src[i * 4 + 2];
+	}
+}
+
+void convert_BGRA8888_to_RGB888(const uint8_t* RESTRICT src, uint8_t* RESTRICT dst, size_t count)
+{
+	for (size_t i = 0; i < count; ++i) {
+		dst[i * 3 + 0] = src[i * 4 + 2]; // R
+		dst[i * 3 + 1] = src[i * 4 + 1]; // G
+		dst[i * 3 + 2] = src[i * 4 + 0]; // B
+	}
+}
+
+void convert_BGR_to_RGB(const uint8_t* RESTRICT src, uint8_t* RESTRICT dst, size_t count)
+{
+	for (size_t i = 0; i < count; ++i) {
+		size_t s = i * 3;
+		size_t t = i * 3;
+		uint8_t b = src[s + 0];
+		uint8_t g = src[s + 1];
+		uint8_t r = src[s + 2];
+		dst[t + 0] = r;
+		dst[t + 1] = g;
+		dst[t + 2] = b;
+	}
+}
+
+void convert_BGR_to_RGBA(const uint8_t* RESTRICT src, uint8_t* RESTRICT dst, size_t count)
+{
+	for (size_t i = 0; i < count; ++i) {
+		size_t s = i * 3;
+		size_t t = i * 4;
+		dst[t + 0] = src[s + 2]; // R <- B
+		dst[t + 1] = src[s + 1]; // G
+		dst[t + 2] = src[s + 0]; // B <- R
+		dst[t + 3] = 255;        // A
+	}
+}
+
+void expand_BGR_to_BGRA(const uint8_t* RESTRICT src, uint8_t* RESTRICT dst, size_t count)
+{
+	for (size_t i = 0; i < count; ++i) {
+		dst[0] = src[0];
+		dst[1] = src[1];
+		dst[2] = src[2];
+		dst[3] = 255;
+		src += 3;
+		dst += 4;
+	}
+}
+
+void convert_BGRA1555_REV_to_RGBA5551(const uint16_t* RESTRICT src, uint16_t* RESTRICT dst, size_t count)
+{
+	for (size_t i = 0; i < count; i++) {
+		const uint16_t s = src[i];
+		uint16_t a = (s >> 15) & 0x1;
+		uint16_t r = (s >> 10) & 0x1F;
+		uint16_t g = (s >> 5) & 0x1F;
+		uint16_t b = (s >> 0) & 0x1F;
+		dst[i] = static_cast<uint16_t>((r << 11) | (g << 6) | (b << 1) | a);
+	}
+}
+
+void convert_BGRA1555_REV_to_RGBA8888(const uint16_t* RESTRICT src, uint8_t* RESTRICT dst, size_t count)
+{
+	for (size_t i = 0; i < count; ++i) {
+		uint16_t s = src[i];
+		uint8_t A = (s >> 15) ? 255 : 0;
+		uint8_t R5 = (s >> 10) & 0x1F;
+		uint8_t G5 = (s >> 5) & 0x1F;
+		uint8_t B5 = s & 0x1F;
+		uint8_t R = (R5 << 3) | (R5 >> 2);
+		uint8_t G = (G5 << 3) | (G5 >> 2);
+		uint8_t B = (B5 << 3) | (B5 >> 2);
+		size_t o = 4 * i;
+		dst[o + 0] = R;
+		dst[o + 1] = G;
+		dst[o + 2] = B;
+		dst[o + 3] = A;
+	}
+}
+
+void convert_BGRA1555_REV_to_RGB888(const uint16_t* RESTRICT src, uint8_t* RESTRICT dst, size_t count)
+{
+	for (size_t i = 0; i < count; ++i) {
+		uint16_t s = src[i];
+		uint8_t R5 = (s >> 10) & 0x1F;
+		uint8_t G5 = (s >> 5) & 0x1F;
+		uint8_t B5 = s & 0x1F;
+		uint8_t R = (R5 << 3) | (R5 >> 2);
+		uint8_t G = (G5 << 3) | (G5 >> 2);
+		uint8_t B = (B5 << 3) | (B5 >> 2);
+		size_t o = 3 * i;
+		dst[o + 0] = R;
+		dst[o + 1] = G;
+		dst[o + 2] = B;
+	}
+}
+
+void expand_R8_to_RGBA(const uint8_t* RESTRICT src, uint8_t* RESTRICT dst, size_t count)
+{
+	for (size_t i = 0; i < count; ++i) {
+		const uint8_t r = src[i];
+		dst[i * 4 + 0] = r;
+		dst[i * 4 + 1] = r;
+		dst[i * 4 + 2] = r;
+		dst[i * 4 + 3] = 255;
+	}
+}
+
+void expand_R8_to_RGB(const uint8_t* RESTRICT src, uint8_t* RESTRICT dst, size_t count)
+{
+	for (size_t i = 0; i < count; ++i) {
+		const uint8_t r = src[i];
+		dst[i * 3 + 0] = r;
+		dst[i * 3 + 1] = r;
+		dst[i * 3 + 2] = r;
+	}
+}
+
+} // namespace util
+} // namespace graphics

--- a/code/graphics/util/pixel_swizzle.h
+++ b/code/graphics/util/pixel_swizzle.h
@@ -1,0 +1,59 @@
+#ifndef PIXEL_SWIZZLE_H
+#define PIXEL_SWIZZLE_H
+
+#include <cstddef>
+#include <cstdint>
+
+#include "globalincs/pstypes.h"
+
+namespace graphics {
+namespace util {
+
+// ---- BGR/BGRA ↔ RGB/RGBA channel swaps ----
+
+// 32-bit BGRA → RGBA (in-place convenience)
+void swizzle_bgra_to_rgba(uint8_t* pixels, size_t count);
+
+// 32-bit BGRA → RGBA (copy, safe for overlapping when src==dst)
+void convert_BGRA8888_to_RGBA8888(const uint8_t* RESTRICT src, uint8_t* RESTRICT dst, size_t count);
+
+// 32-bit BGRA → RGB888 (R/B swap, alpha discarded)
+void convert_BGRA8888_to_RGB888(const uint8_t* RESTRICT src, uint8_t* RESTRICT dst, size_t count);
+
+// 32-bit RGBA → RGB888 (alpha stripped, no channel reorder)
+void convert_RGBA8888_to_RGB888(const uint8_t* RESTRICT src, uint8_t* RESTRICT dst, size_t count);
+
+// 24-bit BGR → RGB
+void convert_BGR_to_RGB(const uint8_t* RESTRICT src, uint8_t* RESTRICT dst, size_t count);
+
+// 24-bit BGR → 32-bit RGBA (alpha = 255)
+void convert_BGR_to_RGBA(const uint8_t* RESTRICT src, uint8_t* RESTRICT dst, size_t count);
+
+// 24-bit BGR → 32-bit BGRA (alpha = 255, preserves BGR channel order)
+void expand_BGR_to_BGRA(const uint8_t* RESTRICT src, uint8_t* RESTRICT dst, size_t count);
+
+// ---- 16-bit A1R5G5B5 / BGRA1555_REV expansion ----
+
+// BGRA1555_REV → RGBA5551
+void convert_BGRA1555_REV_to_RGBA5551(const uint16_t* RESTRICT src, uint16_t* RESTRICT dst, size_t count);
+
+// BGRA1555_REV → RGBA8888 (5→8 bit expansion)
+// Note: BGRA1555_REV layout is identical to A1R5G5B5
+void convert_BGRA1555_REV_to_RGBA8888(const uint16_t* RESTRICT src, uint8_t* RESTRICT dst, size_t count);
+
+// BGRA1555_REV → RGB888 (5→8 bit expansion, alpha discarded)
+// Note: BGRA1555_REV layout is identical to A1R5G5B5
+void convert_BGRA1555_REV_to_RGB888(const uint16_t* RESTRICT src, uint8_t* RESTRICT dst, size_t count);
+
+// ---- Greyscale expansion ----
+
+// R8 → RGBA8888 (R replicated to R/G/B, alpha = 255)
+void expand_R8_to_RGBA(const uint8_t* RESTRICT src, uint8_t* RESTRICT dst, size_t count);
+
+// R8 → RGB888 (R replicated to R/G/B)
+void expand_R8_to_RGB(const uint8_t* RESTRICT src, uint8_t* RESTRICT dst, size_t count);
+
+} // namespace util
+} // namespace graphics
+
+#endif

--- a/code/graphics/vulkan/VulkanDeferred.cpp
+++ b/code/graphics/vulkan/VulkanDeferred.cpp
@@ -147,35 +147,21 @@ void vulkan_deferred_lighting_begin(bool clearNonColorBufs)
 		// Transition MSAA images to expected initial layouts
 		pp->deferred().transitionMsaaForBegin(cmd);
 
-		// Begin MSAA G-buffer render pass (eClear — clears all attachments)
+		// Copy scene color → MSAA emissive via dedicated single-attachment render pass
 		{
+			auto* pipelineMgr = getPipelineManager();
+			auto* descriptorMgr = getDescriptorManager();
+
 			auto extent = pp->getSceneExtent();
 			vk::RenderPassBeginInfo rpBegin;
-			rpBegin.renderPass = pp->deferred().msaaRenderPass();
-			rpBegin.framebuffer = pp->deferred().msaaFramebuffer();
+			rpBegin.renderPass = pp->deferred().msaaEmissiveCopyRenderPass();
+			rpBegin.framebuffer = pp->deferred().msaaEmissiveCopyFramebuffer();
 			rpBegin.renderArea.offset = vk::Offset2D(0, 0);
 			rpBegin.renderArea.extent = extent;
-			std::array<vk::ClearValue, VulkanDeferredGBuffer::MSAA_COLOR_ATTACHMENT_COUNT + 1> clearValues{};
-			clearValues[VulkanDeferredGBuffer::GBUF_ATT_COLOR].color.setFloat32({0.0f, 0.0f, 0.0f, 0.0f});
-			clearValues[VulkanDeferredGBuffer::GBUF_ATT_POSITION].color.setFloat32({0.0f, 0.0f, 0.0f, 0.0f});
-			clearValues[VulkanDeferredGBuffer::GBUF_ATT_NORMAL].color.setFloat32({0.0f, 0.0f, 0.0f, 0.0f});
-			clearValues[VulkanDeferredGBuffer::GBUF_ATT_SPECULAR].color.setFloat32({0.0f, 0.0f, 0.0f, 0.0f});
-			clearValues[VulkanDeferredGBuffer::GBUF_ATT_EMISSIVE].color.setFloat32({0.0f, 0.0f, 0.0f, 0.0f});
-			clearValues[VulkanDeferredGBuffer::MSAA_COLOR_ATTACHMENT_COUNT].depthStencil = vk::ClearDepthStencilValue(1.0f, 0);
+			std::array<vk::ClearValue, 1> clearValues{};
 			rpBegin.clearValueCount = static_cast<uint32_t>(clearValues.size());
 			rpBegin.pClearValues = clearValues.data();
 			cmd.beginRenderPass(rpBegin, vk::SubpassContents::eInline);
-			stateTracker->setRenderPass(pp->deferred().msaaRenderPass(), 0);
-			stateTracker->setColorAttachmentCount(VulkanDeferredGBuffer::MSAA_COLOR_ATTACHMENT_COUNT);
-			stateTracker->setCurrentSampleCount(renderer->getMsaaSampleCount());
-		}
-
-		// Fill MSAA emissive with pre-deferred scene content (starfield, backgrounds).
-		// Draw a fullscreen tri sampling non-MSAA scene color, writing to all attachments.
-		// Only emissive (attachment 4) matters — the other attachments will be overwritten
-		// by model rendering. Use per-attachment color write mask to write only att 4.
-		{
-			auto* pipelineMgr = getPipelineManager();
 
 			PipelineConfig config;
 			config.shaderType = SDR_TYPE_COPY;
@@ -184,27 +170,15 @@ void vulkan_deferred_lighting_begin(bool clearNonColorBufs)
 			config.blendMode = ALPHA_BLEND_NONE;
 			config.cullEnabled = false;
 			config.depthWriteEnabled = false;
-			config.renderPass = pp->deferred().msaaRenderPass();
+			config.renderPass = pp->deferred().msaaEmissiveCopyRenderPass();
 			config.sampleCount = renderer->getMsaaSampleCount();
-			config.colorAttachmentCount = VulkanDeferredGBuffer::MSAA_COLOR_ATTACHMENT_COUNT;
-
-			// Per-attachment blend: only write to emissive
-			config.perAttachmentBlendEnabled = true;
-			for (uint32_t i = 0; i < config.colorAttachmentCount; ++i) {
-				config.attachmentBlends[i].blendMode = ALPHA_BLEND_NONE;
-				config.attachmentBlends[i].writeMask = {false, false, false, false};
-			}
-			config.attachmentBlends[VulkanDeferredGBuffer::GBUF_ATT_EMISSIVE].writeMask = {true, true, true, true};
+			config.colorAttachmentCount = 1;
 
 			vertex_layout emptyLayout;
 			vk::Pipeline pipeline = pipelineMgr->getPipeline(config, emptyLayout);
 			if (pipeline) {
-				// Use drawFullscreenTriangle pattern but inline since we're already in a render pass
-				auto* descriptorMgr = getDescriptorManager();
-
 				cmd.bindPipeline(vk::PipelineBindPoint::eGraphics, pipeline);
 
-				auto extent = pp->getSceneExtent();
 				vk::Viewport viewport;
 				viewport.x = 0.0f;
 				viewport.y = 0.0f;
@@ -218,7 +192,6 @@ void vulkan_deferred_lighting_begin(bool clearNonColorBufs)
 				scissor.extent = extent;
 				cmd.setScissor(0, scissor);
 
-				// Bind descriptors with scene color as source
 				DescriptorWriter writer;
 				writer.reset(descriptorMgr->getDevice(), descriptorMgr->getFallbacks());
 
@@ -229,7 +202,6 @@ void vulkan_deferred_lighting_begin(bool clearNonColorBufs)
 				vk::DescriptorSet materialSet = descriptorMgr->allocateFrameSet(DescriptorSetIndex::Material);
 				Verify(materialSet);
 				writer.writeSet(materialSet, VulkanDescriptorManager::getSetTemplate(DescriptorSetIndex::Material));
-				// Scene color at texture array slot 0
 				{
 					std::array<vk::DescriptorImageInfo, VulkanDescriptorManager::MAX_TEXTURE_BINDINGS> texImages;
 					texImages.fill(descriptorMgr->getFallbacks().texture2D);
@@ -253,6 +225,30 @@ void vulkan_deferred_lighting_begin(bool clearNonColorBufs)
 
 				cmd.draw(3, 1, 0, 0);
 			}
+
+			cmd.endRenderPass();
+		}
+
+		// Begin MSAA G-buffer render pass (eClear for 0-3+depth, eLoad for emissive [4])
+		{
+			auto extent = pp->getSceneExtent();
+			vk::RenderPassBeginInfo rpBegin;
+			rpBegin.renderPass = pp->deferred().msaaRenderPass();
+			rpBegin.framebuffer = pp->deferred().msaaFramebuffer();
+			rpBegin.renderArea.offset = vk::Offset2D(0, 0);
+			rpBegin.renderArea.extent = extent;
+			std::array<vk::ClearValue, VulkanDeferredGBuffer::MSAA_COLOR_ATTACHMENT_COUNT + 1> clearValues{};
+			clearValues[VulkanDeferredGBuffer::GBUF_ATT_COLOR].color.setFloat32({0.0f, 0.0f, 0.0f, 0.0f});
+			clearValues[VulkanDeferredGBuffer::GBUF_ATT_POSITION].color.setFloat32({0.0f, 0.0f, 0.0f, 0.0f});
+			clearValues[VulkanDeferredGBuffer::GBUF_ATT_NORMAL].color.setFloat32({0.0f, 0.0f, 0.0f, 0.0f});
+			clearValues[VulkanDeferredGBuffer::GBUF_ATT_SPECULAR].color.setFloat32({0.0f, 0.0f, 0.0f, 0.0f});
+			clearValues[VulkanDeferredGBuffer::MSAA_COLOR_ATTACHMENT_COUNT].depthStencil = vk::ClearDepthStencilValue(1.0f, 0);
+			rpBegin.clearValueCount = static_cast<uint32_t>(clearValues.size());
+			rpBegin.pClearValues = clearValues.data();
+			cmd.beginRenderPass(rpBegin, vk::SubpassContents::eInline);
+			stateTracker->setRenderPass(pp->deferred().msaaRenderPass(), 0);
+			stateTracker->setColorAttachmentCount(VulkanDeferredGBuffer::MSAA_COLOR_ATTACHMENT_COUNT);
+			stateTracker->setCurrentSampleCount(renderer->getMsaaSampleCount());
 		}
 	} else {
 		// --- Non-MSAA path (original) ---
@@ -385,8 +381,22 @@ void vulkan_deferred_lighting_msaa()
 
 		PipelineConfig config;
 		config.shaderType = SDR_TYPE_MSAA_RESOLVE;
+		switch (getRendererInstance()->getMsaaSampleCount()){
+			case vk::SampleCountFlagBits::e4:
+				config.shaderFlags = SDR_FLAG_MSAA_SAMPLES_4;
+				break;
+			case vk::SampleCountFlagBits::e8:
+				config.shaderFlags = SDR_FLAG_MSAA_SAMPLES_8;
+				break;
+			case vk::SampleCountFlagBits::e16:
+				config.shaderFlags = SDR_FLAG_MSAA_SAMPLES_16;
+				break;
+			default:
+				config.shaderFlags = 0; //Dynamic safety fallback
+				break;
+		}
 		config.primitiveType = PRIM_TYPE_TRIS;
-		config.depthMode = ZBUFFER_TYPE_FULL;
+		config.depthMode = ZBUFFER_TYPE_WRITE;
 		config.blendMode = ALPHA_BLEND_NONE;
 		config.cullEnabled = false;
 		config.depthWriteEnabled = true;

--- a/code/graphics/vulkan/VulkanDraw.cpp
+++ b/code/graphics/vulkan/VulkanDraw.cpp
@@ -240,23 +240,6 @@ void VulkanDrawManager::clear()
 
 void VulkanDrawManager::setClearColor(int r, int g, int b)
 {
-	(void)this;
-	auto* stateTracker = getStateTracker();
-
-	float fr = static_cast<float>(r) / 255.0f;
-	float fg = static_cast<float>(g) / 255.0f;
-	float fb = static_cast<float>(b) / 255.0f;
-
-	// Apply HDR gamma if needed
-	if (High_dynamic_range) {
-		const float SRGB_GAMMA = 2.2f;
-		fr = powf(fr, SRGB_GAMMA);
-		fg = powf(fg, SRGB_GAMMA);
-		fb = powf(fb, SRGB_GAMMA);
-	}
-
-	stateTracker->setClearColor(fr, fg, fb, 1.0f);
-
 	// Also update gr_screen for compatibility
 	gr_screen.current_clear_color.red = static_cast<ubyte>(r);
 	gr_screen.current_clear_color.green = static_cast<ubyte>(g);

--- a/code/graphics/vulkan/VulkanPostProcessing.h
+++ b/code/graphics/vulkan/VulkanPostProcessing.h
@@ -312,6 +312,7 @@ private:
 		vk::ImageLayout colorFinalLayout;
 		vk::ImageLayout depthInitialLayout;
 		bool useResolveDependency = false;
+		SCP_unordered_map<uint32_t, vk::AttachmentLoadOp> attachmentLoadOpOverrides = {};
 	};
 	vk::RenderPass createGbufRenderPass(const GbufRenderPassConfig& config);
 	vk::Framebuffer createGbufFramebuffer(vk::RenderPass renderPass, bool includeComposite,

--- a/code/graphics/vulkan/VulkanPostProcessingFog.cpp
+++ b/code/graphics/vulkan/VulkanPostProcessingFog.cpp
@@ -225,6 +225,8 @@ void VulkanFog::renderScene(vk::CommandBuffer cmd)
 		fogData.fog_color.xyz.z = b / 255.f;
 		fogData.zNear = Min_draw_distance;
 		fogData.zFar = Max_draw_distance;
+		fogData.clip_dist = Neb2_fog_clip_distance;
+		fogData.clip_inf_dist = Neb2_fog_skybox_clip_distance;
 	}
 
 	// Custom descriptor writes to bind depth copy at binding 4

--- a/code/graphics/vulkan/VulkanPostProcessingGBuffer.cpp
+++ b/code/graphics/vulkan/VulkanPostProcessingGBuffer.cpp
@@ -39,10 +39,11 @@ vk::RenderPass VulkanDeferredGBuffer::createGbufRenderPass(const GbufRenderPassC
 
 	// Max 6 color + 1 depth = 7 attachments
 	std::array<vk::AttachmentDescription, 7> attachments;
-	for (uint32_t i = 0; i < colorCount; ++i) {
+		for (uint32_t i = 0; i < colorCount; ++i) {
 		attachments[i].format = COLOR_FORMATS[i];
 		attachments[i].samples = config.samples;
-		attachments[i].loadOp = config.colorLoadOp;
+		auto opIt = config.attachmentLoadOpOverrides.find(i);
+		attachments[i].loadOp = (opIt != config.attachmentLoadOpOverrides.end()) ? opIt->second : config.colorLoadOp;
 		attachments[i].storeOp = vk::AttachmentStoreOp::eStore;
 		attachments[i].stencilLoadOp = vk::AttachmentLoadOp::eDontCare;
 		attachments[i].stencilStoreOp = vk::AttachmentStoreOp::eDontCare;
@@ -53,7 +54,8 @@ vk::RenderPass VulkanDeferredGBuffer::createGbufRenderPass(const GbufRenderPassC
 	// Depth — stencil ops mirror the depth loadOp
 	attachments[depthIndex].format = m_ctx->depthFormat;
 	attachments[depthIndex].samples = config.samples;
-	attachments[depthIndex].loadOp = config.depthLoadOp;
+	auto depthOpIt = config.attachmentLoadOpOverrides.find(depthIndex);
+	attachments[depthIndex].loadOp = (depthOpIt != config.attachmentLoadOpOverrides.end()) ? depthOpIt->second : config.depthLoadOp;
 	attachments[depthIndex].storeOp = vk::AttachmentStoreOp::eStore;
 	attachments[depthIndex].stencilLoadOp = config.depthLoadOp;
 	attachments[depthIndex].stencilStoreOp =

--- a/code/graphics/vulkan/VulkanPostProcessingMSAA.cpp
+++ b/code/graphics/vulkan/VulkanPostProcessingMSAA.cpp
@@ -123,6 +123,8 @@ bool VulkanDeferredGBuffer::initMsaa()
 			vk::AttachmentLoadOp::eClear, vk::AttachmentLoadOp::eClear,
 			vk::ImageLayout::eColorAttachmentOptimal, vk::ImageLayout::eColorAttachmentOptimal,
 			vk::ImageLayout::eDepthStencilAttachmentOptimal,
+			false, // useResolveDependency
+			{{GBUF_ATT_EMISSIVE, vk::AttachmentLoadOp::eLoad}},
 		});
 	} catch (const vk::SystemError& e) {
 		mprintf(("VulkanPostProcessor: Failed to create MSAA G-buffer render pass: %s\n", e.what()));

--- a/code/graphics/vulkan/VulkanState.cpp
+++ b/code/graphics/vulkan/VulkanState.cpp
@@ -40,12 +40,6 @@ bool VulkanStateTracker::init(vk::Device device)
 	m_scissor.extent.width = gr_screen.max_w;
 	m_scissor.extent.height = gr_screen.max_h;
 
-	// Initialize clear color (dark blue for debugging - shows clears are working)
-	m_clearColor.float32[0] = 0.0f;
-	m_clearColor.float32[1] = 0.0f;
-	m_clearColor.float32[2] = 0.3f;
-	m_clearColor.float32[3] = 1.0f;
-
 	m_initialized = true;
 	mprintf(("VulkanStateTracker: Initialized\n"));
 	return true;
@@ -229,14 +223,6 @@ void VulkanStateTracker::bindIndexBuffer(vk::Buffer buffer, vk::DeviceSize offse
 	Assertion(m_cmdBuffer, "bindIndexBuffer called without active command buffer!");
 	Assertion(buffer, "bindIndexBuffer called with null buffer!");
 	m_cmdBuffer.bindIndexBuffer(buffer, offset, indexType);
-}
-
-void VulkanStateTracker::setClearColor(float r, float g, float b, float a)
-{
-	m_clearColor.float32[0] = r;
-	m_clearColor.float32[1] = g;
-	m_clearColor.float32[2] = b;
-	m_clearColor.float32[3] = a;
 }
 
 void VulkanStateTracker::applyDynamicState()

--- a/code/graphics/vulkan/VulkanState.h
+++ b/code/graphics/vulkan/VulkanState.h
@@ -144,17 +144,23 @@ public:
 	 */
 	bool isScissorEnabled() const { return m_scissorEnabled; }
 
-	// ========== Clear Operations ==========
-
 	/**
-	 * @brief Set clear color for next clear operation
-	 */
-	void setClearColor(float r, float g, float b, float a);
-
-	/**
-	 * @brief Get current clear color
-	 */
-	const vk::ClearColorValue& getClearColor() const { return m_clearColor; }
+     * @brief Get current clear color
+     */
+    const vk::ClearColorValue getClearColor() const {
+		// Don't manually store the clear color here, it's a bad idea to have two possibly desynced globals with the same semantics.
+		float fr = static_cast<float>(gr_screen.current_clear_color.red) / 255.0f;
+		float fg = static_cast<float>(gr_screen.current_clear_color.green) / 255.0f;
+		float fb = static_cast<float>(gr_screen.current_clear_color.blue) / 255.0f;
+		// Apply HDR gamma if needed
+		if (High_dynamic_range) {
+			const float SRGB_GAMMA = 2.2f;
+			fr = powf(fr, SRGB_GAMMA);
+			fg = powf(fg, SRGB_GAMMA);
+			fb = powf(fb, SRGB_GAMMA);
+		}
+		return {fr, fg, fb, 1.0f};
+	}
 
 	// ========== Render State Tracking ==========
 
@@ -232,9 +238,6 @@ private:
 	bool m_depthBiasDirty = false;
 	bool m_stencilRefDirty = false;
 	bool m_lineWidthDirty = false;
-
-	// Clear values
-	vk::ClearColorValue m_clearColor;
 
 	// Render state tracking (for FSO compatibility)
 	gr_zbuffer_type m_zbufferMode = ZBUFFER_TYPE_NONE;

--- a/code/graphics/vulkan/VulkanTexture.cpp
+++ b/code/graphics/vulkan/VulkanTexture.cpp
@@ -6,6 +6,7 @@
 #include "VulkanRenderer.h"
 #include "gr_vulkan.h"
 
+#include "graphics/util/pixel_swizzle.h"
 #include "bmpman/bmpman.h"
 #include "ddsutils/ddsutils.h"
 #include "ddsutils/bcdec.h"
@@ -86,19 +87,6 @@ size_t appendLayerCopyRegions(SCP_vector<vk::BufferImageCopy>& regions,
 	return offset - layerBufferOffset;
 }
 
-// Expand 24bpp BGR pixel data to 32bpp BGRA (alpha forced to 255). Vulkan does
-// not support 24bpp optimal-tiling formats, so every upload path widens.
-void expandBgrToBgra(uint8_t* dst, const uint8_t* src, size_t pixelCount)
-{
-	for (size_t i = 0; i < pixelCount; ++i) {
-		dst[0] = src[0];
-		dst[1] = src[1];
-		dst[2] = src[2];
-		dst[3] = 255;
-		src += 3;
-		dst += 4;
-	}
-}
 } // namespace
 
 VulkanTextureManager* getTextureManager()
@@ -644,7 +632,7 @@ bool VulkanTextureManager::uploadAnimationFrames(int handle, bitmap* bm, int com
 
 		// Copy frame data to staging buffer
 		if (!isCompressed && frameBm->bpp == 24) {
-			expandBgrToBgra(dst, reinterpret_cast<const uint8_t*>(frameBm->data),
+			graphics::util::expand_BGR_to_BGRA(reinterpret_cast<const uint8_t*>(frameBm->data), dst,
 				static_cast<size_t>(width) * height);
 		} else {
 			memcpy(dst, reinterpret_cast<const void*>(frameBm->data), layerDataSize);
@@ -823,8 +811,8 @@ bool VulkanTextureManager::uploadCubemap(int handle, bitmap* bm, int compType)
 	// DDS cubemap data layout: face0[mip0..mipN], face1[mip0..mipN], ..., face5[mip0..mipN]
 	if (!isCompressed && bm->bpp == 24) {
 		// Convert BGR to BGRA for all 6 faces
-		expandBgrToBgra(static_cast<uint8_t*>(mapped),
-			reinterpret_cast<const uint8_t*>(bm->data), static_cast<size_t>(faceW) * faceH * 6);
+		graphics::util::expand_BGR_to_BGRA(reinterpret_cast<const uint8_t*>(bm->data),
+			static_cast<uint8_t*>(mapped), static_cast<size_t>(faceW) * faceH * 6);
 	} else {
 		memcpy(mapped, reinterpret_cast<const void*>(bm->data), totalDataSize);
 	}
@@ -1234,8 +1222,8 @@ bool VulkanTextureManager::bm_data(int handle, bitmap* bm, int compType)
 		// Compressed data: copy raw block data directly (includes all mip levels)
 		memcpy(mapped, reinterpret_cast<const void*>(bm->data), dataSize);
 	} else if (bm->bpp == 24) {
-		expandBgrToBgra(static_cast<uint8_t*>(mapped),
-			reinterpret_cast<const uint8_t*>(bm->data), static_cast<size_t>(width) * height);
+		graphics::util::expand_BGR_to_BGRA(reinterpret_cast<const uint8_t*>(bm->data),
+			static_cast<uint8_t*>(mapped), static_cast<size_t>(width) * height);
 	} else {
 		memcpy(mapped, reinterpret_cast<const void*>(bm->data), dataSize);
 	}
@@ -1584,18 +1572,7 @@ void VulkanTextureManager::update_texture(int bitmap_handle, int bpp, const ubyt
 	void* mapped = m_memoryManager->mapMemory(stagingAllocation);
 	Verify(mapped);
 	if (bpp == 24) {
-		// Convert BGR (3 bytes) to BGRA (4 bytes), adding alpha=255
-		const uint8_t* src = data;
-		auto* dst = static_cast<uint8_t*>(mapped);
-		size_t pixelCount = w * h;
-		for (size_t i = 0; i < pixelCount; ++i) {
-			dst[0] = src[0];
-			dst[1] = src[1];
-			dst[2] = src[2];
-			dst[3] = 255;
-			src += 3;
-			dst += 4;
-		}
+		graphics::util::expand_BGR_to_BGRA(data, static_cast<uint8_t*>(mapped), w * h);
 	} else {
 		memcpy(mapped, data, dataSize);
 	}
@@ -1831,13 +1808,8 @@ void VulkanTextureManager::get_bitmap_from_texture(void* data_out, int bitmap_nu
 				}
 			} else {
 				for (uint32_t y = 0; y < h; ++y) {
-					for (uint32_t x = 0; x < w; ++x) {
-						const uint8_t* s = src + (y * copyW + x) * 4;
-						uint8_t* d = dst + (y * w + x) * 3;
-						d[0] = s[0]; // R
-						d[1] = s[1]; // G
-						d[2] = s[2]; // B
-					}
+					graphics::util::convert_RGBA8888_to_RGB888(
+						src + y * copyW * 4, dst + y * w * 3, w);
 				}
 			}
 		} else {
@@ -1847,67 +1819,27 @@ void VulkanTextureManager::get_bitmap_from_texture(void* data_out, int bitmap_nu
 			switch (ts->format) {
 			case vk::Format::eB8G8R8A8Unorm:
 				if (outChannels == 4) {
-					for (uint32_t i = 0; i < pixelCount; ++i) {
-						dst[i * 4 + 0] = src[i * 4 + 2]; // R
-						dst[i * 4 + 1] = src[i * 4 + 1]; // G
-						dst[i * 4 + 2] = src[i * 4 + 0]; // B
-						dst[i * 4 + 3] = src[i * 4 + 3]; // A
-					}
+					graphics::util::convert_BGRA8888_to_RGBA8888(src, dst, pixelCount);
 				} else {
-					for (uint32_t i = 0; i < pixelCount; ++i) {
-						dst[i * 3 + 0] = src[i * 4 + 2]; // R
-						dst[i * 3 + 1] = src[i * 4 + 1]; // G
-						dst[i * 3 + 2] = src[i * 4 + 0]; // B
-					}
+					graphics::util::convert_BGRA8888_to_RGB888(src, dst, pixelCount);
 				}
 				break;
 
 			case vk::Format::eR8Unorm:
 				if (outChannels == 4) {
-					for (uint32_t i = 0; i < pixelCount; ++i) {
-						const uint8_t r = src[i];
-						dst[i * 4 + 0] = r;
-						dst[i * 4 + 1] = r;
-						dst[i * 4 + 2] = r;
-						dst[i * 4 + 3] = 255;
-					}
+					graphics::util::expand_R8_to_RGBA(src, dst, pixelCount);
 				} else {
-					for (uint32_t i = 0; i < pixelCount; ++i) {
-						const uint8_t r = src[i];
-						dst[i * 3 + 0] = r;
-						dst[i * 3 + 1] = r;
-						dst[i * 3 + 2] = r;
-					}
+					graphics::util::expand_R8_to_RGB(src, dst, pixelCount);
 				}
 				break;
 
-			case vk::Format::eA1R5G5B5UnormPack16: {
-				const auto* src16 = reinterpret_cast<const uint16_t*>(src);
+			case vk::Format::eA1R5G5B5UnormPack16:
 				if (outChannels == 4) {
-					for (uint32_t i = 0; i < pixelCount; ++i) {
-						const uint16_t s = src16[i];
-						const uint8_t a = (s >> 15) & 1;
-						const uint8_t r = (s >> 10) & 0x1F;
-						const uint8_t g = (s >> 5) & 0x1F;
-						const uint8_t b = s & 0x1F;
-						dst[i * 4 + 0] = static_cast<uint8_t>((r << 3) | (r >> 2));
-						dst[i * 4 + 1] = static_cast<uint8_t>((g << 3) | (g >> 2));
-						dst[i * 4 + 2] = static_cast<uint8_t>((b << 3) | (b >> 2));
-						dst[i * 4 + 3] = a ? 255u : 0u;
-					}
+					graphics::util::convert_BGRA1555_REV_to_RGBA8888(reinterpret_cast<const uint16_t*>(src), dst, pixelCount);
 				} else {
-					for (uint32_t i = 0; i < pixelCount; ++i) {
-						const uint16_t s = src16[i];
-						const uint8_t r = (s >> 10) & 0x1F;
-						const uint8_t g = (s >> 5) & 0x1F;
-						const uint8_t b = s & 0x1F;
-						dst[i * 3 + 0] = static_cast<uint8_t>((r << 3) | (r >> 2));
-						dst[i * 3 + 1] = static_cast<uint8_t>((g << 3) | (g >> 2));
-						dst[i * 3 + 2] = static_cast<uint8_t>((b << 3) | (b >> 2));
-					}
+					graphics::util::convert_BGRA1555_REV_to_RGB888(reinterpret_cast<const uint16_t*>(src), dst, pixelCount);
 				}
 				break;
-			}
 
 			default: break;
 			}

--- a/code/graphics/vulkan/VulkanTexture.cpp
+++ b/code/graphics/vulkan/VulkanTexture.cpp
@@ -8,6 +8,7 @@
 
 #include "bmpman/bmpman.h"
 #include "ddsutils/ddsutils.h"
+#include "ddsutils/bcdec.h"
 #include "globalincs/systemvars.h"
 
 
@@ -1611,14 +1612,312 @@ void VulkanTextureManager::update_texture(int bitmap_handle, int bpp, const ubyt
 	ts->currentLayout = vk::ImageLayout::eShaderReadOnlyOptimal;
 }
 
-void VulkanTextureManager::get_bitmap_from_texture(void* data_out, int bitmap_num) const
+void VulkanTextureManager::get_bitmap_from_texture(void* data_out, int bitmap_num)
 {
 	if (!m_initialized || !data_out) {
 		return;
 	}
 
-	// TODO: Implement texture readback
-	(void)bitmap_num;
+	auto* ts = bm_get_gr_info<tcache_slot_vulkan>(bitmap_num, true);
+	if (!ts) {
+		return;
+	}
+
+	// Ensure the texture is uploaded to the GPU.  At model load time the
+	// Vulkan slot exists (vulkan_bm_create) but bm_data hasn't been called
+	// yet, so ts->image is null.  This mirrors gr_opengl_tcache_set which
+	// the OpenGL readback calls to guarantee the texture is resident.
+	if (!ts->image) {
+		vulkan_preload(bitmap_num, 0);
+
+		// Re-fetch slot after preload (bm_data may have replaced the image)
+		ts = bm_get_gr_info<tcache_slot_vulkan>(bitmap_num, true);
+		if (!ts || !ts->image) {
+			return;
+		}
+
+		// bm_data submits uploads asynchronously via submitUploadAsync.
+		// Wait for completion so the GPU layout matches ts->currentLayout
+		// before we record the readback barriers.
+		m_graphicsQueue.waitIdle();
+	}
+
+	// Validate static-texture assumption: format must be one known
+	// from the bm_data upload path, and layout must be initialised.
+	Assertion(ts->format != vk::Format::eUndefined,
+		"get_bitmap_from_texture: undefined format on bitmap %d", bitmap_num);
+	Assertion(ts->currentLayout != vk::ImageLayout::eUndefined,
+		"get_bitmap_from_texture: undefined layout on bitmap %d", bitmap_num);
+	Assertion(
+		ts->format == vk::Format::eB8G8R8A8Unorm ||
+		ts->format == vk::Format::eR8Unorm ||
+		ts->format == vk::Format::eA1R5G5B5UnormPack16 ||
+		ts->format == vk::Format::eBc1RgbaUnormBlock ||
+		ts->format == vk::Format::eBc2UnormBlock ||
+		ts->format == vk::Format::eBc3UnormBlock ||
+		ts->format == vk::Format::eBc7UnormBlock,
+		"get_bitmap_from_texture: unsupported format %d on bitmap %d"
+		" — may be a render target or dynamic texture",
+		static_cast<int>(ts->format), bitmap_num);
+
+	const uint32_t w = ts->width;
+	const uint32_t h = ts->height;
+	const uint32_t pixelCount = w * h;
+	const bool isCompressed = (ts->format == vk::Format::eBc1RgbaUnormBlock ||
+	                           ts->format == vk::Format::eBc2UnormBlock ||
+	                           ts->format == vk::Format::eBc3UnormBlock ||
+	                           ts->format == vk::Format::eBc7UnormBlock);
+	const bool hasAlpha = bm_has_alpha_channel(bitmap_num);
+	const int outChannels = hasAlpha ? 4 : 3;
+
+	// ---- calculate source buffer size & per-pixel layout ----
+	size_t srcBytesPerPixel = 0;
+	size_t srcBufferSize = 0;
+	int blockSize = 0;
+	uint32_t blockW = 0;
+	uint32_t blockH = 0;
+
+	if (isCompressed) {
+		switch (ts->format) {
+		case vk::Format::eBc1RgbaUnormBlock: blockSize = BCDEC_BC1_BLOCK_SIZE; break;
+		case vk::Format::eBc2UnormBlock: blockSize = BCDEC_BC2_BLOCK_SIZE; break;
+		case vk::Format::eBc3UnormBlock: blockSize = BCDEC_BC3_BLOCK_SIZE; break;
+		case vk::Format::eBc7UnormBlock: blockSize = BCDEC_BC7_BLOCK_SIZE; break;
+		default: return;
+		}
+		blockW = (w + 3) / 4;
+		blockH = (h + 3) / 4;
+		srcBufferSize = static_cast<size_t>(blockW) * static_cast<size_t>(blockH) * static_cast<size_t>(blockSize);
+	} else {
+		switch (ts->format) {
+		case vk::Format::eB8G8R8A8Unorm: srcBytesPerPixel = 4; break;
+		case vk::Format::eR8Unorm:        srcBytesPerPixel = 1; break;
+		case vk::Format::eA1R5G5B5UnormPack16: srcBytesPerPixel = 2; break;
+		default: return;
+		}
+		srcBufferSize = static_cast<size_t>(pixelCount) * srcBytesPerPixel;
+	}
+
+	// ---- create readback staging buffer ----
+	vk::Buffer stagingBuffer;
+	VulkanAllocation stagingAlloc;
+	{
+		vk::BufferCreateInfo bufferInfo;
+		bufferInfo.size = srcBufferSize;
+		bufferInfo.usage = vk::BufferUsageFlagBits::eTransferDst;
+		bufferInfo.sharingMode = vk::SharingMode::eExclusive;
+
+		try {
+			stagingBuffer = m_device.createBuffer(bufferInfo);
+		} catch (const vk::SystemError& e) {
+			mprintf(("get_bitmap_from_texture: failed to create readback buffer: %s\n", e.what()));
+			return;
+		}
+
+		if (!m_memoryManager->allocateBufferMemory(stagingBuffer, MemoryUsage::GpuToCpu, stagingAlloc)) {
+			m_device.destroyBuffer(stagingBuffer);
+			return;
+		}
+	}
+
+	// ---- record layout-transition + copy command ----
+	const vk::ImageLayout oldLayout = ts->currentLayout;
+	vk::CommandBuffer cmd = beginSingleTimeCommands();
+
+	// Transition to eTransferSrcOptimal (single mip-0, single layer)
+	{
+		vk::ImageMemoryBarrier barrier;
+		barrier.oldLayout = oldLayout;
+		barrier.newLayout = vk::ImageLayout::eTransferSrcOptimal;
+		barrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+		barrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+		barrier.image = ts->image;
+		barrier.subresourceRange.aspectMask = vk::ImageAspectFlagBits::eColor;
+		barrier.subresourceRange.baseMipLevel = 0;
+		barrier.subresourceRange.levelCount = 1;
+		barrier.subresourceRange.baseArrayLayer = ts->arrayIndex;
+		barrier.subresourceRange.layerCount = 1;
+		barrier.srcAccessMask = vk::AccessFlagBits::eShaderRead;
+		barrier.dstAccessMask = vk::AccessFlagBits::eTransferRead;
+
+		cmd.pipelineBarrier(vk::PipelineStageFlagBits::eFragmentShader,
+		                    vk::PipelineStageFlagBits::eTransfer,
+		                    {}, nullptr, nullptr, barrier);
+	}
+
+	// Copy image -> buffer
+	{
+		vk::BufferImageCopy region;
+		region.bufferOffset = 0;
+		region.bufferRowLength = 0;
+		region.bufferImageHeight = 0;
+		region.imageSubresource.aspectMask = vk::ImageAspectFlagBits::eColor;
+		region.imageSubresource.mipLevel = 0;
+		region.imageSubresource.baseArrayLayer = ts->arrayIndex;
+		region.imageSubresource.layerCount = 1;
+		region.imageOffset = vk::Offset3D(0, 0, 0);
+		region.imageExtent = vk::Extent3D(w, h, 1);
+
+		cmd.copyImageToBuffer(ts->image, vk::ImageLayout::eTransferSrcOptimal,
+		                      stagingBuffer, region);
+	}
+
+	// Transition back to original layout
+	{
+		vk::ImageMemoryBarrier barrier;
+		barrier.oldLayout = vk::ImageLayout::eTransferSrcOptimal;
+		barrier.newLayout = oldLayout;
+		barrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+		barrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+		barrier.image = ts->image;
+		barrier.subresourceRange.aspectMask = vk::ImageAspectFlagBits::eColor;
+		barrier.subresourceRange.baseMipLevel = 0;
+		barrier.subresourceRange.levelCount = 1;
+		barrier.subresourceRange.baseArrayLayer = ts->arrayIndex;
+		barrier.subresourceRange.layerCount = 1;
+		barrier.srcAccessMask = vk::AccessFlagBits::eTransferRead;
+		barrier.dstAccessMask = vk::AccessFlagBits::eShaderRead;
+
+		cmd.pipelineBarrier(vk::PipelineStageFlagBits::eTransfer,
+		                    vk::PipelineStageFlagBits::eFragmentShader,
+		                    {}, nullptr, nullptr, barrier);
+	}
+
+	endSingleTimeCommands(cmd); // synchronous submit + waitIdle
+
+	// ---- read back & convert ----
+	void* mapped = m_memoryManager->mapMemory(stagingAlloc);
+	if (mapped) {
+		m_memoryManager->invalidateMemory(stagingAlloc, 0, srcBufferSize);
+
+		if (isCompressed) {
+			const uint32_t copyW = blockW * 4;
+			const uint32_t copyH = blockH * 4;
+			const size_t decompressedSize = static_cast<size_t>(copyW) * static_cast<size_t>(copyH) * 4;
+			SCP_vector<uint8_t> temp(decompressedSize);
+
+			const auto* srcBlock = static_cast<const uint8_t*>(mapped);
+			uint8_t* blockRowBase = temp.data();
+
+			for (uint32_t by = 0; by < blockH; ++by) {
+				uint8_t* blockColBase = blockRowBase;
+				for (uint32_t bx = 0; bx < blockW; ++bx) {
+					switch (ts->format) {
+					case vk::Format::eBc1RgbaUnormBlock:
+						bcdec_bc1(srcBlock, blockColBase, static_cast<int>(copyW * 4));
+						break;
+					case vk::Format::eBc2UnormBlock:
+						bcdec_bc2(srcBlock, blockColBase, static_cast<int>(copyW * 4));
+						break;
+					case vk::Format::eBc3UnormBlock:
+						bcdec_bc3(srcBlock, blockColBase, static_cast<int>(copyW * 4));
+						break;
+					case vk::Format::eBc7UnormBlock:
+						bcdec_bc7(srcBlock, blockColBase, static_cast<int>(copyW * 4));
+						break;
+					default: break;
+					}
+					srcBlock += blockSize;
+					blockColBase += 4 * 4; // 4 pixels wide × 4 bytes/pixel
+				}
+				blockRowBase += static_cast<size_t>(4) * copyW * 4; // 4 rows × full stride
+			}
+
+			const auto* src = temp.data();
+			auto* dst = static_cast<uint8_t*>(data_out);
+			if (outChannels == 4) {
+				for (uint32_t y = 0; y < h; ++y) {
+					memcpy(dst + y * w * 4, src + y * copyW * 4, w * 4);
+				}
+			} else {
+				for (uint32_t y = 0; y < h; ++y) {
+					for (uint32_t x = 0; x < w; ++x) {
+						const uint8_t* s = src + (y * copyW + x) * 4;
+						uint8_t* d = dst + (y * w + x) * 3;
+						d[0] = s[0]; // R
+						d[1] = s[1]; // G
+						d[2] = s[2]; // B
+					}
+				}
+			}
+		} else {
+			const auto* src = static_cast<const uint8_t*>(mapped);
+			auto* dst = static_cast<uint8_t*>(data_out);
+
+			switch (ts->format) {
+			case vk::Format::eB8G8R8A8Unorm:
+				if (outChannels == 4) {
+					for (uint32_t i = 0; i < pixelCount; ++i) {
+						dst[i * 4 + 0] = src[i * 4 + 2]; // R
+						dst[i * 4 + 1] = src[i * 4 + 1]; // G
+						dst[i * 4 + 2] = src[i * 4 + 0]; // B
+						dst[i * 4 + 3] = src[i * 4 + 3]; // A
+					}
+				} else {
+					for (uint32_t i = 0; i < pixelCount; ++i) {
+						dst[i * 3 + 0] = src[i * 4 + 2]; // R
+						dst[i * 3 + 1] = src[i * 4 + 1]; // G
+						dst[i * 3 + 2] = src[i * 4 + 0]; // B
+					}
+				}
+				break;
+
+			case vk::Format::eR8Unorm:
+				if (outChannels == 4) {
+					for (uint32_t i = 0; i < pixelCount; ++i) {
+						const uint8_t r = src[i];
+						dst[i * 4 + 0] = r;
+						dst[i * 4 + 1] = r;
+						dst[i * 4 + 2] = r;
+						dst[i * 4 + 3] = 255;
+					}
+				} else {
+					for (uint32_t i = 0; i < pixelCount; ++i) {
+						const uint8_t r = src[i];
+						dst[i * 3 + 0] = r;
+						dst[i * 3 + 1] = r;
+						dst[i * 3 + 2] = r;
+					}
+				}
+				break;
+
+			case vk::Format::eA1R5G5B5UnormPack16: {
+				const auto* src16 = reinterpret_cast<const uint16_t*>(src);
+				if (outChannels == 4) {
+					for (uint32_t i = 0; i < pixelCount; ++i) {
+						const uint16_t s = src16[i];
+						const uint8_t a = (s >> 15) & 1;
+						const uint8_t r = (s >> 10) & 0x1F;
+						const uint8_t g = (s >> 5) & 0x1F;
+						const uint8_t b = s & 0x1F;
+						dst[i * 4 + 0] = static_cast<uint8_t>((r << 3) | (r >> 2));
+						dst[i * 4 + 1] = static_cast<uint8_t>((g << 3) | (g >> 2));
+						dst[i * 4 + 2] = static_cast<uint8_t>((b << 3) | (b >> 2));
+						dst[i * 4 + 3] = a ? 255u : 0u;
+					}
+				} else {
+					for (uint32_t i = 0; i < pixelCount; ++i) {
+						const uint16_t s = src16[i];
+						const uint8_t r = (s >> 10) & 0x1F;
+						const uint8_t g = (s >> 5) & 0x1F;
+						const uint8_t b = s & 0x1F;
+						dst[i * 3 + 0] = static_cast<uint8_t>((r << 3) | (r >> 2));
+						dst[i * 3 + 1] = static_cast<uint8_t>((g << 3) | (g >> 2));
+						dst[i * 3 + 2] = static_cast<uint8_t>((b << 3) | (b >> 2));
+					}
+				}
+				break;
+			}
+
+			default: break;
+			}
+		}
+
+		m_memoryManager->unmapMemory(stagingAlloc);
+	}
+
+	m_device.destroyBuffer(stagingBuffer);
+	m_memoryManager->freeAllocation(stagingAlloc);
 }
 
 vk::Sampler VulkanTextureManager::getSampler(vk::Filter magFilter, vk::Filter minFilter,

--- a/code/graphics/vulkan/VulkanTexture.h
+++ b/code/graphics/vulkan/VulkanTexture.h
@@ -136,7 +136,7 @@ public:
 	/**
 	 * @brief Read texture data back to CPU
 	 */
-	void get_bitmap_from_texture(void* data_out, int bitmap_num) const;
+	void get_bitmap_from_texture(void* data_out, int bitmap_num);
 
 	// Sampler management
 

--- a/code/graphics/vulkan/gr_vulkan.cpp
+++ b/code/graphics/vulkan/gr_vulkan.cpp
@@ -16,6 +16,7 @@
 #include "backends/imgui_impl_vulkan.h"
 #include "osapi/osapi.h"
 
+#include "graphics/util/pixel_swizzle.h"
 #include "bmpman/bmpman.h"
 #include "cfile/cfile.h"
 #include "cmdline/cmdline.h"
@@ -255,15 +256,6 @@ void vulkan_free_screen(int bmp_id)
 	}
 }
 
-// Swizzle BGRA→RGBA in-place for PNG output (swap chain is B8G8R8A8)
-void swizzle_bgra_to_rgba(ubyte* pixels, size_t pixelCount)
-{
-	for (size_t i = 0; i < pixelCount; i++) {
-		size_t off = i * 4;
-		std::swap(pixels[off + 0], pixels[off + 2]);
-	}
-}
-
 void vulkan_print_screen(const char* filename)
 {
 	ubyte* pixels = nullptr;
@@ -272,7 +264,7 @@ void vulkan_print_screen(const char* filename)
 		return;
 	}
 
-	swizzle_bgra_to_rgba(pixels, static_cast<size_t>(w) * h);
+	graphics::util::swizzle_bgra_to_rgba(pixels, static_cast<size_t>(w) * h);
 
 	char tmp[MAX_PATH_LEN];
 	snprintf(tmp, MAX_PATH_LEN - 1, "screenshots/%s.png", filename);
@@ -294,7 +286,7 @@ SCP_string vulkan_blob_screen()
 		return "";
 	}
 
-	swizzle_bgra_to_rgba(pixels, static_cast<size_t>(w) * h);
+	graphics::util::swizzle_bgra_to_rgba(pixels, static_cast<size_t>(w) * h);
 
 	SCP_string result = png_b64_bitmap(w, h, false, pixels);
 

--- a/code/model/modelinterp.cpp
+++ b/code/model/modelinterp.cpp
@@ -2453,8 +2453,6 @@ void interp_create_transparency_index_buffer(polymodel *pm, int mn)
 			float v = model_list->vert[index].texture_position.v;
 
 			if ( texture_lookup.get_channel_alpha(u, v) < 0.95f) {
-				// temporarily(?) reduced from 0.95f to 0.75f due to certain models (MVP 4.7.3 Triton) having the entire diffuse texture with alpha values less than 1.0f 
-				// which ended up putting the entire geometry into the transparency pass. Somehow looked fine in OpenGL but we have to do this for Vulkan. For now?
 				transparent_tri = true;
 			}
 

--- a/code/source_groups.cmake
+++ b/code/source_groups.cmake
@@ -570,6 +570,8 @@ add_file_folder("Graphics\\\\SoftwareGr\\\\Font"
 add_file_folder("Graphics\\\\Util"
 	graphics/util/GPUMemoryHeap.cpp
 	graphics/util/GPUMemoryHeap.h
+	graphics/util/pixel_swizzle.h
+	graphics/util/pixel_swizzle.cpp
 	graphics/util/primitives.h
 	graphics/util/primitives.cpp
 	graphics/util/uniform_structs.h


### PR DESCRIPTION
Fixes a few issues:
1. Fixes "Z-Fighting"-type issues on some models by implementing texture readback, thus allowing for correct classification of what pipeline (transparent vs deferred) a mesh is rendered in
2. Fixes fog by passing clip values and applying the correct clear color for colored backgrounds
3. Fixes MSAA by a) changing the depth test values to ensure all fragments in the resolve pass are actually written and b) changing the pipeline ordering so as to actually render the background emissive buffer, rather than have it bounce against the non-writable albedo buffer.