### PR TITLE
Make the Commandline authoritative for -res and -vulkan / -opengl

### DIFF
--- a/code/cmdline/cmdline.cpp
+++ b/code/cmdline/cmdline.cpp
@@ -534,6 +534,7 @@ cmdline_parm luadev_arg("-luadev", "Make lua errors non-fatal", AT_NONE);	// Cmd
 cmdline_parm override_arg("-override_data", "Enable override directory", AT_NONE);	// Cmdline_override_data
 cmdline_parm imgui_debug_arg("-imgui_debug", nullptr, AT_NONE);
 cmdline_parm vulkan("-vulkan", nullptr, AT_NONE);
+cmdline_parm opengl("-opengl", nullptr, AT_NONE);
 cmdline_parm multithreading("-threads", nullptr, AT_INT);
 
 char *Cmdline_start_mission = NULL;
@@ -572,7 +573,7 @@ bool Cmdline_slow_frames_ok = false;
 bool Cmdline_lua_devmode = false;
 bool Cmdline_override_data = false;
 bool Cmdline_show_imgui_debug = false;
-bool Cmdline_vulkan = false;
+GraphicsAPI Cmdline_graphics_api = GraphicsAPI::Default;
 int Cmdline_multithreading = 1;
 
 // Other
@@ -2332,7 +2333,10 @@ bool SetCmdlineParams()
 	}
 
 	if (vulkan.found()) {
-		Cmdline_vulkan = true;
+		Cmdline_graphics_api = GraphicsAPI::Vulkan;
+	}
+	else if (opengl.found()) {
+		Cmdline_graphics_api = GraphicsAPI::OpenGL;
 	}
 
 	//Deprecated flags - CommanderDJ

--- a/code/cmdline/cmdline.h
+++ b/code/cmdline/cmdline.h
@@ -13,6 +13,7 @@
 #define FS_CMDLINE_HEADER_FILE
 
 #include <optional>
+#include "graphics/2d.h"
 
 int parse_cmdline(int argc, char *argv[]);
 
@@ -158,7 +159,7 @@ extern bool Cmdline_slow_frames_ok;
 extern bool Cmdline_lua_devmode;
 extern bool Cmdline_override_data;
 extern bool Cmdline_show_imgui_debug;
-extern bool Cmdline_vulkan;
+extern GraphicsAPI Cmdline_graphics_api;
 extern int Cmdline_multithreading;
 
 enum class WeaponSpewType { NONE = 0, STANDARD, ALL };

--- a/code/cutscene/player.cpp
+++ b/code/cutscene/player.cpp
@@ -4,6 +4,8 @@
 #include "cutscene/VideoPresenter.h"
 #include "cutscene/ffmpeg/FFMPEGDecoder.h"
 
+#include "cmdline/cmdline.h"
+
 #include "graphics/2d.h"
 
 #include "globalincs/alphacolors.h"
@@ -52,7 +54,7 @@ void videoPlaybackInit(PlayerState* state) {
 
 	Assert(state != NULL);
 
-	if (gr_screen.mode != GR_STUB) {
+	if (gr_screen.mode != GraphicsAPI::Stub) {
 		// The video presenter is independent of the underlying graphics API
 		state->videoPresenter.reset(new VideoPresenter(state->props));
 	}

--- a/code/decals/decals.cpp
+++ b/code/decals/decals.cpp
@@ -267,7 +267,7 @@ float smoothstep(float edge0, float edge1, float x) {
 namespace decals {
 
 void initialize() {
-	if (gr_screen.mode == GR_STUB) {
+	if (gr_screen.mode == GraphicsAPI::Stub) {
 		Decal_system_active = false;
 		return;
 	}

--- a/code/globalincs/version.cpp
+++ b/code/globalincs/version.cpp
@@ -201,13 +201,13 @@ SCP_string get_version_string()
 
 	// Lets get some more info in here
 	switch (gr_screen.mode) {
-	case GR_OPENGL:
+	case GraphicsAPI::OpenGL:
 		str += " OpenGL";
 		#ifdef USE_OPENGL_ES
 		str += " ES";
 		#endif
 		break;
-	case GR_VULKAN:
+	case GraphicsAPI::Vulkan:
 		str += " Vulkan";
 		break;
 	}

--- a/code/graphics/2d.cpp
+++ b/code/graphics/2d.cpp
@@ -1331,19 +1331,19 @@ void gr_close()
 	bm_close();
 
 	switch (gr_screen.mode) {
-		case GR_OPENGL:
+		case GraphicsAPI::OpenGL:
 #ifdef WITH_OPENGL
 			gr_opengl_cleanup(true);
 #endif
 			break;
 
-		case GR_VULKAN:
+		case GraphicsAPI::Vulkan:
 #ifdef WITH_VULKAN
 			graphics::vulkan::cleanup();
 #endif
 			break;
 
-		case GR_STUB:
+		case GraphicsAPI::Stub:
 			break;
 
 		default:
@@ -1539,25 +1539,25 @@ static void init_colors()
 	Gr_ta_alpha.scale = 17;
 }
 
-static void gr_init_function_pointers(int mode) {
+static void gr_init_function_pointers(GraphicsAPI mode) {
 	gr_screen = {};
 
 	switch (mode) {
-	case GR_OPENGL:
+	case GraphicsAPI::OpenGL:
 #ifdef WITH_OPENGL
 		gr_opengl_init_function_pointers();
 #else
 		Error(LOCATION, "OpenGL renderer was requested but that was not compiled into this build.");
 #endif
 		break;
-	case GR_VULKAN:
+	case GraphicsAPI::Vulkan:
 #ifdef WITH_VULKAN
 		graphics::vulkan::initialize_function_pointers();
 #else
 		Error(LOCATION, "Vulkan renderer was requested but that was not compiled into this build.");
 #endif
 		break;
-	case GR_STUB:
+	case GraphicsAPI::Stub:
 		gr_stub_init_function_pointers();
 		break;
 	default:
@@ -1565,7 +1565,7 @@ static void gr_init_function_pointers(int mode) {
 	}
 }
 
-static bool gr_init_sub(std::unique_ptr<os::GraphicsOperations>&& graphicsOps, int mode, int width, int height,
+static bool gr_init_sub(std::unique_ptr<os::GraphicsOperations>&& graphicsOps, GraphicsAPI mode, int width, int height,
 						int depth, float center_aspect_ratio)
 {
 	int res = GR_1024;
@@ -1599,7 +1599,7 @@ static bool gr_init_sub(std::unique_ptr<os::GraphicsOperations>&& graphicsOps, i
 	if (Fred_running) {
 		gr_screen.custom_size = false;
 		res = GR_640;
-		mode = GR_OPENGL;
+		mode = GraphicsAPI::OpenGL;
 	}
 
 	Save_custom_screen_size = gr_screen.custom_size;
@@ -1667,7 +1667,7 @@ static bool gr_init_sub(std::unique_ptr<os::GraphicsOperations>&& graphicsOps, i
 	init_colors();
 
 	switch (mode) {
-	case GR_OPENGL:
+	case GraphicsAPI::OpenGL:
 #ifdef WITH_OPENGL
 		rc = gr_opengl_init(std::move(graphicsOps));
 #else
@@ -1675,7 +1675,7 @@ static bool gr_init_sub(std::unique_ptr<os::GraphicsOperations>&& graphicsOps, i
 		rc = false;
 #endif
 		break;
-	case GR_VULKAN:
+	case GraphicsAPI::Vulkan:
 #ifdef WITH_VULKAN
 		rc = graphics::vulkan::initialize(std::move(graphicsOps));
 #else
@@ -1683,7 +1683,7 @@ static bool gr_init_sub(std::unique_ptr<os::GraphicsOperations>&& graphicsOps, i
 		rc = false;
 #endif
 		break;
-	case GR_STUB:
+	case GraphicsAPI::Stub:
 		SCP_UNUSED(graphicsOps);
 		rc = gr_stub_init();
 		break;
@@ -1739,21 +1739,22 @@ SCP_string gr_capability_to_human_readable_string(gr_capability capability)
 		return "Invalid Capability";
 }
 
-bool gr_init(std::unique_ptr<os::GraphicsOperations>&& graphicsOps, int d_mode, int d_width, int d_height, int d_depth)
+bool gr_init(std::unique_ptr<os::GraphicsOperations>&& graphicsOps, GraphicsAPI d_mode, int d_width, int d_height, int d_depth)
 {
-	int width = 1024, height = 768, depth = 32, mode = GR_OPENGL;
+	int width = 1024, height = 768, depth = 32;
+	GraphicsAPI mode = GraphicsAPI::OpenGL;
 	float center_aspect_ratio = -1.0f;
 	const char *ptr = NULL;
 	// If already inited, shutdown the previous graphics
 	if (Gr_inited) {
 		switch (gr_screen.mode) {
-			case GR_OPENGL:
+			case GraphicsAPI::OpenGL:
 #ifdef WITH_OPENGL
 				gr_opengl_cleanup(false);
 #endif
 				break;
 			
-			case GR_STUB:
+			case GraphicsAPI::Stub:
 				break;
 	
 			default:
@@ -1763,7 +1764,7 @@ bool gr_init(std::unique_ptr<os::GraphicsOperations>&& graphicsOps, int d_mode, 
 
 	if (Using_in_game_options) {
 		if (Cmdline_enable_vr) {
-			// in VR mode, so set resolution using VR values 
+			// in VR mode, so set resolution using VR values
 			// and hide/disable the default resolution option
 			auto res = ResolutionVROption->getValue();
 			width = res.width;
@@ -1777,6 +1778,7 @@ bool gr_init(std::unique_ptr<os::GraphicsOperations>&& graphicsOps, int d_mode, 
 			height = res.height;
 			removeResolutionVROption();
 		}
+		//TODO set d_mode from Ingame Options if available here
 	} else if ( !Is_standalone ) {
 		// We cannot continue without this, quit, but try to help the user out first
 		ptr = os_config_read_string(nullptr, NOX("VideocardFs2open"), nullptr);
@@ -1836,26 +1838,31 @@ bool gr_init(std::unique_ptr<os::GraphicsOperations>&& graphicsOps, int d_mode, 
 			SCP_string videoApi(ptr, ptr + 4);
 
 			if (videoApi == "OGL ") {
-				d_mode = GR_OPENGL; // GR_OPENGL;
+				d_mode = GraphicsAPI::OpenGL; // GR_OPENGL;
 			} else if (videoApi == "VK  ") {
-				d_mode = GR_VULKAN;
+				d_mode = GraphicsAPI::Vulkan;
 			} else {
 				ReleaseWarning(LOCATION, "Unknown video API '%s'", videoApi.c_str());
 			}
 		}
 
-		if (Cmdline_res != nullptr) {
-			int tmp_width = 0;
-			int tmp_height = 0;
-
-			if ( sscanf(Cmdline_res, "%dx%d", &tmp_width, &tmp_height) == 2 ) {
-				width = tmp_width;
-				height = tmp_height;
-			}
-		}
-
 		Gr_enable_soft_particles = Cmdline_softparticles != 0;
 	}
+
+	//Commandline ALWAYS wins for Graphics API and resolution
+	if (Cmdline_graphics_api != GraphicsAPI::Default)
+		d_mode = Cmdline_graphics_api;
+
+	if (Cmdline_res != nullptr) {
+		int tmp_width = 0;
+		int tmp_height = 0;
+
+		if ( sscanf(Cmdline_res, "%dx%d", &tmp_width, &tmp_height) == 2 ) {
+			width = tmp_width;
+			height = tmp_height;
+		}
+	}
+
 	if (Cmdline_center_res != NULL) {
 		int tmp_center_width = 0;
 		int tmp_center_height = 0;
@@ -1878,9 +1885,9 @@ bool gr_init(std::unique_ptr<os::GraphicsOperations>&& graphicsOps, int d_mode, 
 		Cmdline_window_res.emplace(static_cast<uint16_t>(width), static_cast<uint16_t>(height));
 	}
 
-	if (d_mode == GR_DEFAULT) {
-		// OpenGL should be default
-		mode = GR_OPENGL;
+	if (d_mode == GraphicsAPI::Default) {
+		// OpenGL should be default.
+		mode = GraphicsAPI::OpenGL;
 	} else {
 		mode = d_mode;
 	}
@@ -1897,7 +1904,7 @@ bool gr_init(std::unique_ptr<os::GraphicsOperations>&& graphicsOps, int d_mode, 
 
 	// if we are in standalone mode then just use special defaults
 	if (Is_standalone) {
-		mode = GR_STUB;
+		mode = GraphicsAPI::Stub;
 		width = 640;
 		height = 480;
 		depth = 16;
@@ -2192,7 +2199,7 @@ void gr_bitmap(int _x, int _y, int resize_mode, bool mirror, float scale_factor)
 	float x, y, w, h;
 	vertex verts[4];
 
-	if (gr_screen.mode == GR_STUB) {
+	if (gr_screen.mode == GraphicsAPI::Stub) {
 		return;
 	}
 
@@ -2913,7 +2920,7 @@ void gr_set_bitmap(int bitmap_num, int alphablend_mode, int bitblt_mode, float a
 
 static void output_uniform_debug_data()
 {
-	if (gr_screen.mode == GR_STUB) {
+	if (gr_screen.mode == GraphicsAPI::Stub) {
 		return;
 	}
 
@@ -3006,7 +3013,7 @@ void gr_print_timestamp(int x, int y, fix timestamp, int resize_mode)
 
 static void uniform_buffer_managers_init()
 {
-	if (gr_screen.mode == GR_STUB) {
+	if (gr_screen.mode == GraphicsAPI::Stub) {
 		return;
 	}
 
@@ -3015,7 +3022,7 @@ static void uniform_buffer_managers_init()
 
 static void uniform_buffer_managers_deinit()
 {
-	if (gr_screen.mode == GR_STUB) {
+	if (gr_screen.mode == GraphicsAPI::Stub) {
 		return;
 	}
 
@@ -3024,7 +3031,7 @@ static void uniform_buffer_managers_deinit()
 
 static void uniform_buffer_managers_retire_buffers()
 {
-	if (gr_screen.mode == GR_STUB) {
+	if (gr_screen.mode == GraphicsAPI::Stub) {
 		return;
 	}
 
@@ -3165,7 +3172,7 @@ size_t vertex_layout::hash() const {
 static std::unique_ptr<graphics::util::GPUMemoryHeap> gpu_heaps [static_cast<size_t>(GpuHeap::NUM_VALUES)];
 
 static void gpu_heap_init() {
-	if (gr_screen.mode == GR_STUB) {
+	if (gr_screen.mode == GraphicsAPI::Stub) {
 		return;
 	}
 
@@ -3264,7 +3271,7 @@ static void make_gamma_ramp(float gamma, ushort* ramp)
 
 void gr_set_gamma(float gamma)
 {
-	if (gr_screen.mode == GR_STUB) {
+	if (gr_screen.mode == GraphicsAPI::Stub) {
 		return;
 	}
 

--- a/code/graphics/2d.h
+++ b/code/graphics/2d.h
@@ -41,6 +41,9 @@ extern float Min_draw_distance;
 extern float Max_draw_distance;
 extern int Gr_inited;
 
+// # Software Re-added by Kazan --- THIS HAS TO STAY -- It is used by standalone!
+enum class GraphicsAPI : uint8_t { Default, Stub, OpenGL, Vulkan };
+
 // z-buffering stuff
 extern int gr_zbuffering, gr_zbuffering_mode;
 extern int gr_global_zbuffering;
@@ -672,7 +675,7 @@ typedef struct screen {
 	int save_center_w = 0, save_center_h = 0; // Width and height of center monitor
 	int save_center_offset_x = 0, save_center_offset_y = 0;
 	int res = 0;                             // GR_640 or GR_1024
-	int mode = 0;                            // What mode gr_init was called with.
+	GraphicsAPI mode = GraphicsAPI::Default;                            // What mode gr_init was called with.
 	float aspect = 0.0f, clip_aspect = 0.0f; // Aspect ratio = 0, aspect of clip_width/clip_height
 	int rowsize = 0;                         // What you need to add to go to next row (includes bytes_per_pixel)
 	int bits_per_pixel = 0;                  // How many bits per pixel it is. (7,8,15,16,24,32)
@@ -990,11 +993,7 @@ bool gr_lua_context_active();
 //--------------------------------------
 // Call this at application startup
 
-// # Software Re-added by Kazan --- THIS HAS TO STAY -- It is used by standalone!
-#define GR_DEFAULT				(-1)		// set to use default settings
-#define GR_STUB					(100)
-#define GR_OPENGL (104) // Use OpenGl hardware renderer
-#define GR_VULKAN (105) // Use Vulkan hardware renderer
+#define GR_DEFAULT (-1)
 
 // resolution constants   - always keep resolutions in ascending order and starting from 0  
 #define GR_NUM_RESOLUTIONS			2
@@ -1006,7 +1005,7 @@ bool gr_lua_context_active();
 
 extern const char *Resolution_prefixes[GR_NUM_RESOLUTIONS];
 
-extern bool gr_init(std::unique_ptr<os::GraphicsOperations>&& graphicsOps, int d_mode = GR_DEFAULT,
+extern bool gr_init(std::unique_ptr<os::GraphicsOperations>&& graphicsOps, GraphicsAPI d_mode = GraphicsAPI::Default,
 					int d_width = GR_DEFAULT, int d_height = GR_DEFAULT, int d_depth = GR_DEFAULT);
 
 extern void gr_screen_resize(int width, int height);

--- a/code/graphics/light.cpp
+++ b/code/graphics/light.cpp
@@ -201,7 +201,7 @@ static void pre_render_init_lights() {
 }
 
 void gr_set_light(light* fs_light) {
-	if (gr_screen.mode == GR_STUB) {
+	if (gr_screen.mode == GraphicsAPI::Stub) {
 		return;
 	}
 
@@ -213,7 +213,7 @@ void gr_set_light(light* fs_light) {
 }
 
 void gr_set_center_alpha(int type) {
-	if (gr_screen.mode == GR_STUB) {
+	if (gr_screen.mode == GraphicsAPI::Stub) {
 		return;
 	}
 
@@ -274,7 +274,7 @@ void gr_set_center_alpha(int type) {
 }
 
 void gr_reset_lighting() {
-	if (gr_screen.mode == GR_STUB) {
+	if (gr_screen.mode == GraphicsAPI::Stub) {
 		return;
 	}
 
@@ -287,7 +287,7 @@ void gr_light_shutdown() {
 }
 
 void gr_light_init() {
-	if (gr_screen.mode == GR_STUB) {
+	if (gr_screen.mode == GraphicsAPI::Stub) {
 		return;
 	}
 
@@ -296,7 +296,7 @@ void gr_light_init() {
 }
 
 void gr_set_lighting() {
-	if (gr_screen.mode == GR_STUB) {
+	if (gr_screen.mode == GraphicsAPI::Stub) {
 		return;
 	}
 
@@ -329,7 +329,7 @@ void gr_set_lighting() {
 }
 
 void gr_set_ambient_light(int red, int green, int blue) {
-	if (gr_screen.mode == GR_STUB) {
+	if (gr_screen.mode == GraphicsAPI::Stub) {
 		return;
 	}
 
@@ -357,7 +357,7 @@ void gr_get_ambient_light(vec3d* light_vector) {
 }
 
 void gr_lighting_fill_uniforms(void* data_out, size_t buffer_size) {
-	if (gr_screen.mode == GR_STUB) {
+	if (gr_screen.mode == GraphicsAPI::Stub) {
 		return;
 	}
 

--- a/code/graphics/matrix.cpp
+++ b/code/graphics/matrix.cpp
@@ -2,6 +2,7 @@
 #include "matrix.h"
 
 #include "graphics/util/UniformBuffer.h"
+#include "cmdline/cmdline.h"
 
 #include <graphics/util/uniform_structs.h>
 
@@ -58,7 +59,7 @@ static void create_perspective_projection_matrix(matrix4 *out, float left, float
 	out->a1d[9] = (top + bottom) / (top - bottom);
 	out->a1d[11] = -1.0f;
 
-	if (gr_screen.mode == GR_VULKAN) {
+	if (gr_screen.mode == GraphicsAPI::Vulkan) {
 		// Vulkan NDC Z range is [0, 1] (OpenGL is [-1, 1])
 		// Y-flip is handled by negative viewport height (VK_KHR_maintenance1)
 		out->a1d[10] = -far_dist / (far_dist - near_dist);
@@ -80,7 +81,7 @@ static void create_orthographic_projection_matrix(matrix4* out, float left, floa
 	out->a1d[13] = -(top + bottom) / (top - bottom);
 	out->a1d[15] = 1.0f;
 
-	if (gr_screen.mode == GR_VULKAN) {
+	if (gr_screen.mode == GraphicsAPI::Vulkan) {
 		// Vulkan NDC Z range is [0, 1] (OpenGL is [-1, 1])
 		// Y-flip is handled by negative viewport height (VK_KHR_maintenance1)
 		out->a1d[10] = -1.0f / (far_dist - near_dist);

--- a/code/graphics/opengl/gropengl.cpp
+++ b/code/graphics/opengl/gropengl.cpp
@@ -1649,7 +1649,7 @@ DCF(ogl_anisotropy, "toggles anisotropic filtering")
 	bool process = true;
 	int value;
 
-	if ( gr_screen.mode != GR_OPENGL ) {
+	if ( gr_screen.mode != GraphicsAPI::OpenGL ) {
 		dc_printf("Can only set anisotropic filter in OpenGL mode.\n");
 		return;
 	}

--- a/code/graphics/opengl/gropenglopenxr.cpp
+++ b/code/graphics/opengl/gropenglopenxr.cpp
@@ -11,6 +11,7 @@
 // the other platforms do not go before the #includes because this will cause conflicts from symbols defined in XLib,
 // specifically None and Always; see https://stackoverflow.com/questions/22476110/c-compiling-error-including-x11-x-h-x11-xlib-h
 
+#include "cmdline/cmdline.h"
 #include "io/cursor.h"
 #include "io/mouse.h"
 #include "graphics/matrix.h"

--- a/code/graphics/opengl/gropengltexture.cpp
+++ b/code/graphics/opengl/gropengltexture.cpp
@@ -1230,7 +1230,7 @@ int gr_opengl_tcache_set(int bitmap_handle, int bitmap_type, float *u_scale, flo
 
 void opengl_preload_init()
 {
-	if (gr_screen.mode != GR_OPENGL)
+	if (gr_screen.mode != GraphicsAPI::OpenGL)
 		return;
 
 //	opengl_tcache_flush ();
@@ -1241,7 +1241,7 @@ int gr_opengl_preload(int bitmap_num, int is_aabitmap)
 	float u_scale, v_scale;
 	int retval;
 
-	Assert( gr_screen.mode == GR_OPENGL );
+	Assert( gr_screen.mode == GraphicsAPI::OpenGL );
 
 	if ( !GL_should_preload ) {
 		return 0;

--- a/code/graphics/post_processing.cpp
+++ b/code/graphics/post_processing.cpp
@@ -260,7 +260,7 @@ void PostProcessingManager::setBloomShadersOk(bool ok)
 
 bool gr_lightshafts_enabled()
 {
-	if (gr_screen.mode == GR_STUB) {
+	if (gr_screen.mode == GraphicsAPI::Stub) {
 		return false;
 	}
 
@@ -278,7 +278,7 @@ bool gr_lightshafts_enabled()
 
 bool gr_sunglare_enabled()
 {
-	if (gr_screen.mode == GR_STUB) {
+	if (gr_screen.mode == GraphicsAPI::Stub) {
 		return false;
 	}
 
@@ -292,7 +292,7 @@ bool gr_sunglare_enabled()
 
 int gr_bloom_intensity()
 {
-	if (gr_screen.mode == GR_STUB) {
+	if (gr_screen.mode == GraphicsAPI::Stub) {
 		return 0;
 	}
 
@@ -305,7 +305,7 @@ int gr_bloom_intensity()
 
 void gr_set_bloom_intensity(int intensity)
 {
-	if (gr_screen.mode == GR_STUB) {
+	if (gr_screen.mode == GraphicsAPI::Stub) {
 		return;
 	}
 

--- a/code/graphics/render.cpp
+++ b/code/graphics/render.cpp
@@ -47,7 +47,7 @@ static void gr_flash_internal(int r, int g, int b, int a, bool alpha_flash)
 }
 
 void gr_flash(int r, int g, int b) {
-	if (gr_screen.mode == GR_STUB) {
+	if (gr_screen.mode == GraphicsAPI::Stub) {
 		return;
 	}
 
@@ -59,7 +59,7 @@ void gr_flash(int r, int g, int b) {
 }
 
 void gr_flash_alpha(int r, int g, int b, int a) {
-	if (gr_screen.mode == GR_STUB) {
+	if (gr_screen.mode == GraphicsAPI::Stub) {
 		return;
 	}
 
@@ -167,7 +167,7 @@ static void bitmap_ex_internal(int x,
 }
 
 void gr_aabitmap(int x, int y, int resize_mode, bool mirror, float scale_factor) {
-	if (gr_screen.mode == GR_STUB) {
+	if (gr_screen.mode == GraphicsAPI::Stub) {
 		return;
 	}
 
@@ -254,7 +254,7 @@ void gr_aabitmap(int x, int y, int resize_mode, bool mirror, float scale_factor)
 					   scale_factor);
 }
 void gr_aabitmap_ex(int x, int y, int w, int h, int sx, int sy, int resize_mode, bool mirror, float scale_factor) {
-	if (gr_screen.mode == GR_STUB) {
+	if (gr_screen.mode == GraphicsAPI::Stub) {
 		return;
 	}
 
@@ -406,7 +406,7 @@ void gr_aabitmap_ex(int x, int y, int w, int h, int sx, int sy, int resize_mode,
 }
 //these are penguins bitmap functions
 void gr_bitmap_ex(int x, int y, int w, int h, int sx, int sy, int resize_mode, bool mirror, float scale_factor) {
-	if (gr_screen.mode == GR_STUB) {
+	if (gr_screen.mode == GraphicsAPI::Stub) {
 		return;
 	}
 
@@ -793,7 +793,7 @@ void endDrawing(graphics::paths::PathRenderer* path) {
 
 void gr_string(float sx, float sy, const char* s, int resize_mode, float scaleMultiplier, size_t in_length)
 {
-	if (gr_screen.mode == GR_STUB) {
+	if (gr_screen.mode == GraphicsAPI::Stub) {
 		return;
 	}
 
@@ -996,7 +996,7 @@ static void gr_line(float x1, float y1, float x2, float y2, int resize_mode) {
 }
 
 void gr_line(int x1, int y1, int x2, int y2, int resize_mode) {
-	if (gr_screen.mode == GR_STUB) {
+	if (gr_screen.mode == GraphicsAPI::Stub) {
 		return;
 	}
 
@@ -1004,7 +1004,7 @@ void gr_line(int x1, int y1, int x2, int y2, int resize_mode) {
 }
 
 void gr_aaline(vertex* v1, vertex* v2) {
-	if (gr_screen.mode == GR_STUB) {
+	if (gr_screen.mode == GraphicsAPI::Stub) {
 		return;
 	}
 
@@ -1018,7 +1018,7 @@ void gr_aaline(vertex* v1, vertex* v2) {
 }
 
 void gr_gradient(int x1, int y1, int x2, int y2, int resize_mode) {
-	if (gr_screen.mode == GR_STUB) {
+	if (gr_screen.mode == GraphicsAPI::Stub) {
 		return;
 	}
 
@@ -1044,7 +1044,7 @@ void gr_gradient(int x1, int y1, int x2, int y2, int resize_mode) {
 	endDrawing(path);
 }
 void gr_pixel(int x, int y, int resize_mode) {
-	if (gr_screen.mode == GR_STUB) {
+	if (gr_screen.mode == GraphicsAPI::Stub) {
 		return;
 	}
 
@@ -1052,7 +1052,7 @@ void gr_pixel(int x, int y, int resize_mode) {
 }
 
 void gr_circle(int xc, int yc, int d, int resize_mode) {
-	if (gr_screen.mode == GR_STUB) {
+	if (gr_screen.mode == GraphicsAPI::Stub) {
 		return;
 	}
 
@@ -1065,7 +1065,7 @@ void gr_circle(int xc, int yc, int d, int resize_mode) {
 	endDrawing(path);
 }
 void gr_unfilled_circle(int xc, int yc, int d, int resize_mode) {
-	if (gr_screen.mode == GR_STUB) {
+	if (gr_screen.mode == GraphicsAPI::Stub) {
 		return;
 	}
 
@@ -1078,7 +1078,7 @@ void gr_unfilled_circle(int xc, int yc, int d, int resize_mode) {
 	endDrawing(path);
 }
 void gr_arc(int xc, int yc, float r, float angle_start, float angle_end, bool fill, int resize_mode) {
-	if (gr_screen.mode == GR_STUB) {
+	if (gr_screen.mode == GraphicsAPI::Stub) {
 		return;
 	}
 
@@ -1108,7 +1108,7 @@ void gr_arc(int xc, int yc, float r, float angle_start, float angle_end, bool fi
 	endDrawing(path);
 }
 void gr_curve(int xc, int yc, int r, int direction, int resize_mode) {
-	if (gr_screen.mode == GR_STUB) {
+	if (gr_screen.mode == GraphicsAPI::Stub) {
 		return;
 	}
 
@@ -1159,7 +1159,7 @@ void gr_curve(int xc, int yc, int r, int direction, int resize_mode) {
 }
 
 void gr_rect(int x, int y, int w, int h, int resize_mode, float angle) {
-	if (gr_screen.mode == GR_STUB) {
+	if (gr_screen.mode == GraphicsAPI::Stub) {
 		return;
 	}
 
@@ -1180,7 +1180,7 @@ void gr_rect(int x, int y, int w, int h, int resize_mode, float angle) {
 }
 
 void gr_shade(int x, int y, int w, int h, int resize_mode) {
-	if (gr_screen.mode == GR_STUB) {
+	if (gr_screen.mode == GraphicsAPI::Stub) {
 		return;
 	}
 
@@ -1202,7 +1202,7 @@ void gr_shade(int x, int y, int w, int h, int resize_mode) {
 }
 
 void gr_2d_start_buffer() {
-	if (gr_screen.mode == GR_STUB) {
+	if (gr_screen.mode == GraphicsAPI::Stub) {
 		return;
 	}
 
@@ -1215,7 +1215,7 @@ void gr_2d_start_buffer() {
 }
 
 void gr_2d_stop_buffer() {
-	if (gr_screen.mode == GR_STUB) {
+	if (gr_screen.mode == GraphicsAPI::Stub) {
 		return;
 	}
 
@@ -1233,7 +1233,7 @@ static size_t immediate_buffer_size = 0;
 static const size_t IMMEDIATE_BUFFER_RESIZE_BLOCK_SIZE = 2048;
 
 size_t gr_add_to_immediate_buffer(size_t size, void* data) {
-	if (gr_screen.mode == GR_STUB) {
+	if (gr_screen.mode == GraphicsAPI::Stub) {
 		return 0;
 	}
 
@@ -1263,7 +1263,7 @@ size_t gr_add_to_immediate_buffer(size_t size, void* data) {
 	return old_offset;
 }
 void gr_reset_immediate_buffer() {
-	if (gr_screen.mode == GR_STUB) {
+	if (gr_screen.mode == GraphicsAPI::Stub) {
 		return;
 	}
 
@@ -1285,7 +1285,7 @@ void gr_render_primitives_immediate(material* material_info,
 									int n_verts,
 									void* data,
 									size_t size) {
-	if (gr_screen.mode == GR_STUB) {
+	if (gr_screen.mode == GraphicsAPI::Stub) {
 		return;
 	}
 
@@ -1301,7 +1301,7 @@ void gr_render_primitives_2d_immediate(material* material_info,
 	void* data,
 	size_t size)
 {
-	if (gr_screen.mode == GR_STUB) {
+	if (gr_screen.mode == GraphicsAPI::Stub) {
 		return;
 	}
 
@@ -1458,7 +1458,7 @@ static void draw_bitmap_list(bitmap_rect_list* list, int n_bm, int resize_mode, 
 
 void gr_bitmap_list(bitmap_rect_list* list, int n_bm, int resize_mode, float angle)
 {
-	if (gr_screen.mode == GR_STUB) {
+	if (gr_screen.mode == GraphicsAPI::Stub) {
 		return;
 	}
 
@@ -1473,7 +1473,7 @@ void gr_bitmap_list(bitmap_rect_list* list, int n_bm, int resize_mode, float ang
 
 void gr_aabitmap_list(bitmap_rect_list* list, int n_bm, int resize_mode, float angle)
 {
-	if (gr_screen.mode == GR_STUB) {
+	if (gr_screen.mode == GraphicsAPI::Stub) {
 		return;
 	}
 

--- a/code/graphics/shadows.cpp
+++ b/code/graphics/shadows.cpp
@@ -104,7 +104,7 @@ void shadows_construct_light_proj(light_frustum_info *shadow_data)
 	shadow_data->proj_matrix.a1d[13] = -(shadow_data->max.xyz.y + shadow_data->min.xyz.y) / ( shadow_data->max.xyz.y - shadow_data->min.xyz.y );
 	shadow_data->proj_matrix.a1d[15] = 1.0f;
 
-	if (gr_screen.mode == GR_VULKAN) {
+	if (gr_screen.mode == GraphicsAPI::Vulkan) {
 		// Vulkan uses [0, 1] depth range
 		shadow_data->proj_matrix.a1d[10] = -1.0f / ( shadow_data->max.xyz.z - shadow_data->min.xyz.z );
 		shadow_data->proj_matrix.a1d[14] = -shadow_data->min.xyz.z / ( shadow_data->max.xyz.z - shadow_data->min.xyz.z );
@@ -472,7 +472,7 @@ void shadows_end_render()
 
 void shadows_render_all(fov_t fov, matrix *eye_orient, vec3d *eye_pos)
 {
-	if (gr_screen.mode == GR_STUB) {
+	if (gr_screen.mode == GraphicsAPI::Stub) {
 		return;
 	}
 

--- a/code/hud/hudconfig.cpp
+++ b/code/hud/hudconfig.cpp
@@ -11,6 +11,7 @@
 
 
 #include "cfile/cfile.h"
+#include "cmdline/cmdline.h"
 #include "gamesequence/gamesequence.h"
 #include "gamesnd/gamesnd.h"
 #include "globalincs/alphacolors.h"

--- a/code/io/cursor.cpp
+++ b/code/io/cursor.cpp
@@ -187,7 +187,7 @@ namespace io
 
 		Cursor* CursorManager::loadFromBitmap(int bitmapHandle)
 		{
-			Assertion(gr_screen.mode != GR_STUB, "Cursors can not be used with the stub renderer!");
+			Assertion(gr_screen.mode != GraphicsAPI::Stub, "Cursors can not be used with the stub renderer!");
 
 			Assertion(bm_is_valid(bitmapHandle), "%d is no valid bitmap handle!", bitmapHandle);
 

--- a/code/io/cursor.h
+++ b/code/io/cursor.h
@@ -6,7 +6,6 @@
 #include <SDL_mouse.h>
 
 #include "globalincs/pstypes.h"
-#include "cmdline/cmdline.h"
 #include "io/timer.h"
 
 #include <memory>

--- a/code/localization/localize.cpp
+++ b/code/localization/localize.cpp
@@ -12,6 +12,7 @@
 
 #include <cctype>
 
+#include "cmdline/cmdline.h"
 #include "cfile/cfile.h"
 #include "localization/localize.h"
 #include "osapi/osregistry.h"

--- a/code/menuui/optionsmenu.cpp
+++ b/code/menuui/optionsmenu.cpp
@@ -12,6 +12,7 @@
 
 #include "bmpman/bmpman.h"
 #include "freespace.h"
+#include "cmdline/cmdline.h"
 #include "controlconfig/controlsconfig.h"
 #include "gamesequence/gamesequence.h"
 #include "gamesnd/eventmusic.h"

--- a/code/mission/missioncampaign.cpp
+++ b/code/mission/missioncampaign.cpp
@@ -27,6 +27,7 @@
 #include "freespace.h"
 #include "missioncampaign.h"
 #include "cfile/cfile.h"
+#include "cmdline/cmdline.h"
 #include "cutscene/cutscenes.h"
 #include "cutscene/movie.h"
 #include "gamesequence/gamesequence.h"

--- a/code/mod_table/mod_table.cpp
+++ b/code/mod_table/mod_table.cpp
@@ -7,6 +7,7 @@
  * as the "mod table", and contains many misc FSO specific settings.
  */
 
+#include "cmdline/cmdline.h"
 #include "gamesnd/eventmusic.h"
 #include "def_files/def_files.h"
 #include "globalincs/version.h"

--- a/code/network/multi_fstracker.cpp
+++ b/code/network/multi_fstracker.cpp
@@ -11,6 +11,7 @@
 #include <netinet/in.h>
 #endif
 
+#include "cmdline/cmdline.h"
 #include "freespace.h"
 #include "io/timer.h"
 #include "gamesequence/gamesequence.h"

--- a/code/object/objcollide.cpp
+++ b/code/object/objcollide.cpp
@@ -8,6 +8,7 @@
 */ 
 
 
+#include "cmdline/cmdline.h"
 #include "globalincs/linklist.h"
 #include "io/timer.h"
 #include "object/objcollide.h"

--- a/code/options/manager/ingame_options_manager.cpp
+++ b/code/options/manager/ingame_options_manager.cpp
@@ -7,6 +7,8 @@
 #include "options/Option.h"
 #include "popup/popup.h"
 
+#include "cmdline/cmdline.h"
+
 #include "freespace.h"
 
 

--- a/code/osapi/osapi.cpp
+++ b/code/osapi/osapi.cpp
@@ -8,7 +8,7 @@
  */
 
 #include "freespace.h"
-
+#include "cmdline/cmdline.h"
 #include "gamesequence/gamesequence.h"
 #include "globalincs/pstypes.h"
 #include "parse/parselo.h"

--- a/code/osapi/outwnd.cpp
+++ b/code/osapi/outwnd.cpp
@@ -16,6 +16,7 @@
 #include <direct.h>
 #endif
 
+#include "cmdline/cmdline.h"
 #include "osapi/DebugWindow.h"
 #include "osapi/osapi.h"
 #include "osapi/outwnd.h"

--- a/code/parse/parselo.cpp
+++ b/code/parse/parselo.cpp
@@ -15,6 +15,7 @@
 #include <csetjmp>
 
 #include <cctype>
+#include "cmdline/cmdline.h"
 #include "globalincs/version.h"
 #include "localization/fhash.h"
 #include "localization/localize.h"

--- a/code/scripting/api/libs/graphics.cpp
+++ b/code/scripting/api/libs/graphics.cpp
@@ -19,6 +19,7 @@
 
 #include <asteroid/asteroid.h>
 #include <camera/camera.h>
+#include <cmdline/cmdline.h>
 #include <debris/debris.h>
 #include <freespace.h>
 #include <globalincs/systemvars.h>

--- a/code/starfield/starfield.cpp
+++ b/code/starfield/starfield.cpp
@@ -954,7 +954,7 @@ void stars_post_level_init()
 	float dist, dist_max;
 	ubyte red,green,blue,alpha;
 
-	if (gr_screen.mode == GR_STUB) {
+	if (gr_screen.mode == GraphicsAPI::Stub) {
 		return;
 	}
 
@@ -1274,7 +1274,7 @@ void stars_draw_sun(int show_sun)
 	starfield_bitmap *bm;
 	float local_scale;
 
-	if (gr_screen.mode == GR_STUB) {
+	if (gr_screen.mode == GraphicsAPI::Stub) {
 		return;
 	}
 
@@ -1359,7 +1359,7 @@ void stars_draw_lens_flare(vertex *sun_vex, int sun_n)
 	float dx,dy;
 	vertex flare_vex = *sun_vex; //copy over to flare_vex to get all sorts of properties
 
-	if (gr_screen.mode == GR_STUB) {
+	if (gr_screen.mode == GraphicsAPI::Stub) {
 		return;
 	}
 
@@ -1414,7 +1414,7 @@ void stars_draw_sun_glow(int sun_n)
 	vertex sun_vex;	
 	float local_scale;
 
-	if (gr_screen.mode == GR_STUB) {
+	if (gr_screen.mode == GraphicsAPI::Stub) {
 		return;
 	}
 
@@ -1487,7 +1487,7 @@ void stars_draw_bitmaps(int show_bitmaps)
 	int idx;
 	int star_index;
 
-	if (gr_screen.mode == GR_STUB) {
+	if (gr_screen.mode == GraphicsAPI::Stub) {
 		return;
 	}
 
@@ -1616,7 +1616,7 @@ void subspace_render()
 {
 	int framenum = 0;
 
-	if (gr_screen.mode == GR_STUB) {
+	if (gr_screen.mode == GraphicsAPI::Stub) {
 		return;
 	}
 
@@ -1758,7 +1758,7 @@ void stars_draw_stars()
 	vertex p1, p2;
 	int can_draw = 1;
 
-	if (gr_screen.mode == GR_STUB) {
+	if (gr_screen.mode == GraphicsAPI::Stub) {
 		return;
 	}
 
@@ -1870,7 +1870,7 @@ void stars_draw_motion_debris()
 	GR_DEBUG_SCOPE("Draw motion debris");
 	TRACE_SCOPE(tracing::DrawMotionDebris);
 
-	if (gr_screen.mode == GR_STUB) {
+	if (gr_screen.mode == GraphicsAPI::Stub) {
 		return;
 	}
 
@@ -1933,7 +1933,7 @@ void stars_draw(int show_stars, int show_suns, int  /*show_nebulas*/, int show_s
 	GR_DEBUG_SCOPE("Draw Stars");
 	TRACE_SCOPE(tracing::DrawStars);
 
-	if (gr_screen.mode == GR_STUB) {
+	if (gr_screen.mode == GraphicsAPI::Stub) {
 		return;
 	}
 
@@ -2058,7 +2058,7 @@ void stars_page_in()
 {
 	int idx, i;
 
-	if (gr_screen.mode == GR_STUB) {
+	if (gr_screen.mode == GraphicsAPI::Stub) {
 		return;
 	}
 
@@ -2302,7 +2302,7 @@ void stars_draw_background()
 	GR_DEBUG_SCOPE("Draw Background");
 	TRACE_SCOPE(tracing::DrawBackground);
 
-	if (gr_screen.mode == GR_STUB) {
+	if (gr_screen.mode == GraphicsAPI::Stub) {
 		return;
 	}
 
@@ -2344,7 +2344,7 @@ void stars_draw_background()
 
 void stars_set_background_model(int new_model, int new_bitmap, uint64_t flags, float alpha)
 {
-	if (gr_screen.mode == GR_STUB) {
+	if (gr_screen.mode == GraphicsAPI::Stub) {
 		return;
 	}
 
@@ -2392,7 +2392,7 @@ void stars_set_background_model(const char* model_name, const char* texture_name
 	int new_model = -1;
 	int new_bitmap = -1;
 
-	if (gr_screen.mode == GR_STUB) {
+	if (gr_screen.mode == GraphicsAPI::Stub) {
 		return;
 	}
 
@@ -3097,7 +3097,7 @@ void stars_setup_environment_mapping(camid cid) {
 	extern fov_t View_zoom;
 	fov_t old_zoom = View_zoom, new_zoom = 1.0f;//0.925f;
 
-	if (gr_screen.mode == GR_STUB) {
+	if (gr_screen.mode == GraphicsAPI::Stub) {
 		return;
 	}
 

--- a/code/tracing/tracing.cpp
+++ b/code/tracing/tracing.cpp
@@ -4,6 +4,7 @@
 #include "globalincs/systemvars.h"
 #include "parse/parselo.h"
 #include "io/timer.h"
+#include "cmdline/cmdline.h"
 
 #include "TraceEventWriter.h"
 #include "MainFrameTimer.h"

--- a/freespace2/SDLGraphicsOperations.cpp
+++ b/freespace2/SDLGraphicsOperations.cpp
@@ -3,6 +3,7 @@
 
 #include "SDLGraphicsOperations.h"
 
+#include "backends/imgui_impl_vulkan.h"
 #include "cmdline/cmdline.h"
 
 #if SDL_VERSION_ATLEAST(2, 0, 6)
@@ -177,8 +178,18 @@ SDLGraphicsOperations::~SDLGraphicsOperations() {
 			ImGui_ImplSDL2_Shutdown();
 		}
 
-		if ( !Cmdline_vulkan && ImGui::GetIO().BackendRendererUserData ) {
-			ImGui_ImplOpenGL3_Shutdown();
+		if ( ImGui::GetIO().BackendRendererUserData ) {
+			switch (gr_screen.mode) {
+				case GraphicsAPI::OpenGL:
+					ImGui_ImplOpenGL3_Shutdown();
+					break;
+				case GraphicsAPI::Vulkan:
+					ImGui_ImplVulkan_Shutdown();
+					break;
+				default:
+					break;
+			}
+
 		}
 	}
 

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -1911,11 +1911,7 @@ void game_init()
 		sdlGraphicsOperations.reset(new SDLGraphicsOperations());
 	}
 
-	int graphics_api = GR_DEFAULT;
-	if (Cmdline_vulkan)
-		graphics_api = GR_VULKAN;
-
-	if (!gr_init(std::move(sdlGraphicsOperations), graphics_api)) {
+	if (!gr_init(std::move(sdlGraphicsOperations))) {
 		os::dialogs::Message(os::dialogs::MESSAGEBOX_ERROR, "Error initializing graphics!");
 		exit(1);
 		return;

--- a/test/src/util/FSTestFixture.cpp
+++ b/test/src/util/FSTestFixture.cpp
@@ -52,7 +52,7 @@ void test::FSTestFixture::SetUp() {
 		}
 
 		if (_initFlags & INIT_GRAPHICS) {
-			if (!gr_init(nullptr, GR_STUB, 1024, 768)) {
+			if (!gr_init(nullptr, GraphicsAPI::Stub, 1024, 768)) {
 				FAIL() << "Graphics init failed!";
 			}
 


### PR DESCRIPTION
This makes the -res and -vulkan command line switches authoritative over ingame options or ini file.
Also adds -opengl to force back to opengl should the ini get misconfigured or ingame options for the graphics API be added at some point.